### PR TITLE
Adding 'extra' param for self.client.get/post kwargs.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,11 +72,17 @@ to pass in.
 get(url\_name, \*args, \*\*kwargs)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Another thing you do often is HTTP get urls, our ``get()`` method
-assumes you are passing in a named URL with any arguments necessary::
+Another thing you do often is HTTP get urls. Our ``get()`` method
+assumes you are passing in a named URL with any args or kwargs necessary
+to reverse the url\_name.
+If needed, place kwargs for ``TestClient.get()`` in an 'extra' dictionary.::
 
     def test_get_named_url(self):
         response = self.get('my-url-name')
+        # Get XML data via AJAX request
+        xml_response = self.get(
+            'my-url-name',
+            extra={'HTTP_X_REQUESTED_WITH': 'XMLHttpRequest'})
 
 When using this get method two other things happen for you, we store the
 last response in
@@ -99,10 +105,12 @@ post(url\_name, data, \*args, \*\*kwargs)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Our ``post()`` method takes a named URL, the dictionary of data you wish
-to post and any args or kwargs necessary to reverse the url\_name.::
+to post and any args or kwargs necessary to reverse the url\_name.
+If needed, place kwargs for ``TestClient.post()`` in an 'extra' dictionary.::
 
     def test_post_named_url(self):
-        response = self.post('my-url-name', data={'coolness-factor': 11.0})
+        response = self.post('my-url-name', data={'coolness-factor': 11.0},
+                             extra={'HTTP_X_REQUESTED_WITH': 'XMLHttpRequest'})
 
 assertInContext(key)
 ~~~~~~~~~~~~~~~~~~~~

--- a/test_plus/test.py
+++ b/test_plus/test.py
@@ -100,14 +100,16 @@ class TestCase(TestCase):
 
     def get(self, url_name, *args, **kwargs):
         """ GET url by name using reverse() """
-        self.last_response = self.client.get(reverse(url_name, args=args, kwargs=kwargs))
+        extra = kwargs.pop("extra", {})
+        self.last_response = self.client.get(reverse(url_name, args=args, kwargs=kwargs), **extra)
         self.context = self.last_response.context
         return self.last_response
 
     def post(self, url_name, *args, **kwargs):
         """ POST to url by name using reverse() """
         data = kwargs.pop("data", None)
-        self.last_response = self.client.post(reverse(url_name, args=args, kwargs=kwargs), data)
+        extra = kwargs.pop("extra", {})
+        self.last_response = self.client.post(reverse(url_name, args=args, kwargs=kwargs), data, **extra)
         return self.last_response
 
     def response_200(self, response):

--- a/test_project/test_app/tests.py
+++ b/test_project/test_app/tests.py
@@ -137,3 +137,14 @@ class TestPlusViewTests(TestCase):
     def test_no_response(self):
         with self.assertRaises(NoPreviousResponse):
             self.assertInContext('testvalue')
+
+    def test_get_is_ajax(self):
+        response = self.get('view-is-ajax',
+                            extra={'HTTP_X_REQUESTED_WITH': 'XMLHttpRequest'})
+        self.response_200(response)
+
+    def test_post_is_ajax(self):
+        response = self.post('view-is-ajax',
+                             data={'item': 1},
+                             extra={'HTTP_X_REQUESTED_WITH': 'XMLHttpRequest'})
+        self.response_200(response)

--- a/test_project/test_app/urls.py
+++ b/test_project/test_app/urls.py
@@ -5,7 +5,7 @@ except ImportError:
 
 from .views import (
     view_200, view_201, view_302, view_404, needs_login, data_1,
-    data_5, view_context_with, view_context_without
+    data_5, view_context_with, view_context_without, view_is_ajax
 )
 
 
@@ -20,4 +20,5 @@ urlpatterns = patterns('',
     url(r'^view/data5/$', data_5, name='view-data-5'),
     url(r'^view/context/with/$', view_context_with, name='view-context-with'),
     url(r'^view/context/without/$', view_context_without, name='view-context-without'),
+    url(r'^view/isajax/$', view_is_ajax, name='view-is-ajax'),
 )

--- a/test_project/test_app/views.py
+++ b/test_project/test_app/views.py
@@ -46,3 +46,7 @@ def view_context_with(request):
 
 def view_context_without(request):
     return render(request, 'base.html', {})
+
+
+def view_is_ajax(request):
+    return HttpResponse('', status=200 if request.is_ajax() else 404)


### PR DESCRIPTION
@frankwiles Since all TestCase.get/post() kwargs (except 'data') were passed to reverse(), there was no way to pass kwargs to self.client.get/post(). This problem appeared for me when trying to set HTTP_X_REQUESTED_WITH.

This might improve test coverage as well, for TestCase.post().