### PR TITLE
Honor password when passing User to login class

### DIFF
--- a/test_plus/test.py
+++ b/test_plus/test.py
@@ -1,7 +1,7 @@
 import warnings
 import django
 from django.conf import settings
-from django.core.urlresolvers import reverse, resolve, NoReverseMatch
+from django.core.urlresolvers import reverse, NoReverseMatch
 from django.db import connections, DEFAULT_DB_ALIAS
 from django.test import TestCase
 from distutils.version import LooseVersion
@@ -66,7 +66,6 @@ class login(object):
         if args and isinstance(args[0], User):
             credentials.update({
                 'username': args[0].username,
-                'password': 'password',
             })
 
         if not credentials.get('password', False):
@@ -178,24 +177,24 @@ class TestCase(TestCase):
         return login(self, *args, **credentials)
 
     def reverse(self, name, *args, **kwargs):
-        """ Reverse a url, convience to avoid having to import reverse in tests """
+        """ Reverse a url, convenience to avoid having to import reverse in tests """
         return reverse(name, args=args, kwargs=kwargs)
 
-    def make_user(self, username):
+    def make_user(self, username, password='password'):
         """
         Build a user with <username> and password of 'password' for testing
         purposes.  Exposes the user as self.user_<username>
         """
         if self.user_factory:
             test_user = self.user_factory(username=username)
-            test_user.set_password('password')
+            test_user.set_password(password)
             test_user.save()
             return test_user
         else:
             test_user = User.objects.create_user(
                 username,
                 '{0}@example.com'.format(username),
-                'password',
+                password,
             )
             return test_user
 

--- a/test_project/test_app/tests.py
+++ b/test_project/test_app/tests.py
@@ -105,6 +105,12 @@ class TestPlusViewTests(TestCase):
         with self.login(username='test', password='password'):
             self.get_check_200('view-needs-login')
 
+    def test_login_other_password(self):
+        # Make a user with a different password
+        user = self.make_user('test', password='revsys')
+        with self.login(user, password='revsys'):
+            self.get_check_200('view-needs-login')
+
     def test_login_no_password(self):
 
         user = self.make_user('test')


### PR DESCRIPTION
The login class always used "password" when the initial argument was a User instance. This fix updates login class to use the specified password (if provided!) when initial argument is a User. If no password is provided in credentials then "password" is still used by default.

In order to test this, TestCase.make_user() also needed a default password argument, which is probably a Good Thing in any case.