### PR TITLE
Adds the follow argument to get and post

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -5,3 +5,4 @@ With contributions from:
 Graham Ullrich <graham@flyingcracker.com>
 Brent O'Connor <epicserve@gmail.com>
 Gert Van Gool <gertvangool@gmail.com>
+Daniel Roy Greenfeld <pydanny@gmail.com>

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,11 @@
 Changes
 =======
 
+version 1.0.6 - ???? ????, 2015
+-------------------------------
+
+  - get/post test methods now accept the `follow` boolean.
+
 version 1.0.5 - June 16th, 2015
 -------------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -74,8 +74,8 @@ When testing views you often find yourself needing to reverse the URL's name. Wi
 As you can see our reverse also passes along any args or kwargs you need
 to pass in.
 
-get(url\_name, \*args, \*\*kwargs)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+get(url\_name, follow=True, \*args, \*\*kwargs)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Another thing you do often is HTTP get urls. Our ``get()`` method
 assumes you are passing in a named URL with any args or kwargs necessary
@@ -119,8 +119,8 @@ If you need to pass query string parameters to your url name, you can do so like
 
 Would GET /search/?query=testing
 
-post(url\_name, data, \*args, \*\*kwargs)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+post(url\_name, data, follow=True, \*args, \*\*kwargs)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Our ``post()`` method takes a named URL, the dictionary of data you wish
 to post and any args or kwargs necessary to reverse the url\_name.

--- a/test_plus/test.py
+++ b/test_plus/test.py
@@ -105,7 +105,7 @@ class TestCase(TestCase):
     def tearDown(self):
         self.client.logout()
 
-    def get(self, url_name, *args, **kwargs):
+    def get(self, url_name, follow=False, *args, **kwargs):
         """
         GET url by name using reverse()
 
@@ -114,14 +114,14 @@ class TestCase(TestCase):
         extra = kwargs.pop("extra", {})
         data = kwargs.pop("data", {})
         try:
-            self.last_response = self.client.get(reverse(url_name, args=args, kwargs=kwargs), data=data, **extra)
+            self.last_response = self.client.get(reverse(url_name, args=args, kwargs=kwargs), data=data, follow=follow, **extra)
         except NoReverseMatch:
-            self.last_response = self.client.get(url_name, data=data, **extra)
+            self.last_response = self.client.get(url_name, data=data, follow=follow, **extra)
 
         self.context = self.last_response.context
         return self.last_response
 
-    def post(self, url_name, *args, **kwargs):
+    def post(self, url_name, follow=False, *args, **kwargs):
         """
         POST to url by name using reverse()
 
@@ -130,9 +130,9 @@ class TestCase(TestCase):
         data = kwargs.pop("data", None)
         extra = kwargs.pop("extra", {})
         try:
-            self.last_response = self.client.post(reverse(url_name, args=args, kwargs=kwargs), data, **extra)
+            self.last_response = self.client.post(reverse(url_name, args=args, kwargs=kwargs), data, follow=follow, **extra)
         except NoReverseMatch:
-            self.last_response = self.client.post(url_name, data, **extra)
+            self.last_response = self.client.post(url_name, data, follow=follow, **extra)
 
         return self.last_response
 

--- a/test_project/test_app/tests.py
+++ b/test_project/test_app/tests.py
@@ -51,6 +51,15 @@ class TestPlusViewTests(TestCase):
         res = self.get(url)
         self.assertEqual(res.status_code, 200)
 
+    def test_get_follow(self):
+        # Expect 302 status code
+        res = self.get('view-redirect')
+        self.assertEqual(res.status_code, 302)
+        # Expect 200 status code
+        url = self.reverse('view-redirect')
+        res = self.get(url, follow=True)
+        self.assertEqual(res.status_code, 200)
+
     def test_get_query(self):
         res = self.get('view-200', data={'query': 'foo'})
         self.assertEqual(res.status_code, 200)
@@ -60,6 +69,16 @@ class TestPlusViewTests(TestCase):
         url = self.reverse('view-200')
         data = {'testing': True}
         res = self.post(url, data=data)
+        self.assertTrue(res.status_code, 200)
+
+    def test_post_follow(self):
+        url = self.reverse('view-redirect')
+        data = {'testing': True}
+        # Expect 302 status code
+        res = self.post(url, data=data)
+        self.assertTrue(res.status_code, 302)
+        # Expect 200 status code
+        res = self.post(url, data=data, follow=True)
         self.assertTrue(res.status_code, 200)
 
     def test_get_check_200(self):

--- a/test_project/test_app/urls.py
+++ b/test_project/test_app/urls.py
@@ -5,7 +5,7 @@ except ImportError:
 
 from .views import (
     view_200, view_201, view_302, view_403, view_404, needs_login, data_1,
-    data_5, view_context_with, view_context_without, view_is_ajax
+    data_5, view_context_with, view_context_without, view_is_ajax, view_redirect
 )
 
 
@@ -16,6 +16,7 @@ urlpatterns = patterns('',
     url(r'^view/302/$', view_302, name='view-302'),
     url(r'^view/403/$', view_403, name='view-403'),
     url(r'^view/404/$', view_404, name='view-404'),
+    url(r'^view/redirect/$', view_redirect, name='view-redirect'),
     url(r'^view/needs-login/$', needs_login, name='view-needs-login'),
     url(r'^view/data1/$', data_1, name='view-data-1'),
     url(r'^view/data5/$', data_5, name='view-data-5'),

--- a/test_project/test_app/views.py
+++ b/test_project/test_app/views.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.views import generic
 
 from .models import Data
@@ -26,6 +26,10 @@ def view_403(request):
 
 def view_404(request):
     return HttpResponse('', status=404)
+
+
+def view_redirect(request):
+    return redirect('view-200')
 
 
 @login_required


### PR DESCRIPTION
It is not unusual when writing Django tests to use the `follow` argument. While this is especially common when writing `POST` tests for forms, it can also occur with `GET` tests. What this pull request does is add this argument (defaulting to `False`) and then pass it along to the underlying test methods. 