### PR TITLE
Fix pypandoc requirement typo.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,4 @@
 # using the library.
 -r requirements-travisci.txt
 
-pypdandoc==0.9.7
+pypandoc==0.9.7


### PR DESCRIPTION
Quick fix for a typo (I believe - I could not find the listed package on PyPI).