### PR TITLE
Introspect the USERNAME_FIELD on custom User models

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
   - DJANGO="Django==1.6.11"
   - DJANGO="Django==1.7.8"
   - DJANGO="Django==1.8.2"
+  - DJANGO="Django==1.9.6"
 
 matrix:
   exclude:

--- a/test_plus/test.py
+++ b/test_plus/test.py
@@ -70,8 +70,9 @@ class login(object):
         self.testcase = testcase
 
         if args and isinstance(args[0], User):
+            USERNAME_FIELD = getattr(User, 'USERNAME_FIELD', 'username')
             credentials.update({
-                User.USERNAME_FIELD: getattr(args[0], User.USERNAME_FIELD),
+                USERNAME_FIELD: getattr(args[0], USERNAME_FIELD),
             })
 
         if not credentials.get('password', False):
@@ -204,8 +205,10 @@ class TestCase(DjangoTestCase):
         purposes.
         """
         if self.user_factory:
+            USERNAME_FIELD = getattr(
+                self.user_factory._meta.model, 'USERNAME_FIELD', 'username')
             test_user = self.user_factory(**{
-                self.user_factory._meta.model.USERNAME_FIELD: username,
+                USERNAME_FIELD: username,
             })
             test_user.set_password(password)
             test_user.save()

--- a/test_plus/test.py
+++ b/test_plus/test.py
@@ -71,7 +71,7 @@ class login(object):
 
         if args and isinstance(args[0], User):
             credentials.update({
-                'username': args[0].username,
+                User.USERNAME_FIELD: getattr(args[0], User.USERNAME_FIELD),
             })
 
         if not credentials.get('password', False):
@@ -204,7 +204,9 @@ class TestCase(DjangoTestCase):
         purposes.
         """
         if self.user_factory:
-            test_user = self.user_factory(username=username)
+            test_user = self.user_factory(**{
+                self.user_factory._meta.model.USERNAME_FIELD: username,
+            })
             test_user.set_password(password)
             test_user.save()
         else:

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,23 @@
+[tox]
+envlist = py27-dj14,py{27,33,34}-dj{15,16,17,18,19}
+skip_missing_interpreters = True
+
+[testenv]
+basepython =
+    py27: python2.7
+    py33: python3.3
+    py34: python3.4
+
+deps =
+    dj14: Django~=1.4.0
+    dj15: Django~=1.5.0
+    dj16: Django~=1.6.0
+    dj17: Django~=1.7.0
+    dj18: Django~=1.8.0
+    dj19: Django~=1.9.0
+    factory-boy
+    flake8
+
+commands =
+    flake8 . --ignore=E501,E402
+    coverage run --source=test_plus setup.py test


### PR DESCRIPTION
The library used to make the assumption that the `USERNAME_FIELD` was always going to be `username` however this is easily overloaded.

This allows testing of the following form:

    class MyTest(TestCase):

        user_factory = MyUserFactory

        def test_some_feature(self):
            u1 = self.make_user()
            self.login(u1):
                self.assertTrue(True)

Assuming custom User model, such as:

    class User(AbstractBaseUser, PermissionsMixin):

        email = EmailField(
            verbose_name='email address',
            max_length=255,
            unique=True,
        )

        USERNAME_FIELD = 'email'