### PR TITLE
Add assertResponseContains & assertResponseNotContains methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
 
 install:
   - pip install -e .
@@ -26,3 +27,10 @@ matrix:
     # Django 1.9 doesn't support Python 3.3
     - python: "3.3"
       env: DJANGO="Django==1.9.6"
+    # Django<1.8 doesn't support Python 3.5
+    - python: "3.5"
+      env: DJANGO="Django==1.5.12"
+    - python: "3.5"
+      env: DJANGO="Django==1.6.11"
+    - python: "3.5"
+      env: DJANGO="Django==1.7.8"

--- a/docs/methods.rst
+++ b/docs/methods.rst
@@ -140,6 +140,24 @@ can do::
 
 Which is a bit shorter.
 
+assertResponseContains(text, response=None, html=True)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You often want to check that the last response contains a chunk of HTML. With
+Django's default TestCase you would write::
+
+    from django.core.urlresolvers import reverse
+
+    def test_response_contains(self):
+        response = self.client.get(reverse('hello-world'))
+        self.assertContains(response, '<p>Hello, World!</p>', html=True)
+
+With django-test-plus you can shorten that to be::
+
+    def test_response_contains(self):
+        self.get('hello-world')
+        self.assertResponseContains('<p>Hello, World!</p>')
+
 get\_check\_200(url\_name, \*args, \*\*kwargs)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/methods.rst
+++ b/docs/methods.rst
@@ -158,6 +158,16 @@ With django-test-plus you can shorten that to be::
         self.get('hello-world')
         self.assertResponseContains('<p>Hello, World!</p>')
 
+assertResponseNotContains(text, response=None, html=True)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The inverse of the above test, make sure the last response does not include
+the chunk of HTML::
+
+    def test_response_not_contains(self):
+        self.get('hello-world')
+        self.assertResponseNotContains('<p>Hello, Frank!</p>')
+
 get\_check\_200(url\_name, \*args, \*\*kwargs)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/test_plus/test.py
+++ b/test_plus/test.py
@@ -288,6 +288,11 @@ class TestCase(DjangoTestCase):
         response = self._which_response(response)
         self.assertContains(response, text, html=html, **kwargs)
 
+    def assertResponseNotContains(self, text, response=None, html=True, **kwargs):
+        """ Convenience wrapper for assertNotContains """
+        response = self._which_response(response)
+        self.assertNotContains(response, text, html=html, **kwargs)
+
     def get_context(self, key):
         if self.last_response is not None:
             self.assertTrue(key in self.last_response.context)

--- a/test_plus/test.py
+++ b/test_plus/test.py
@@ -283,6 +283,11 @@ class TestCase(DjangoTestCase):
         else:
             raise NoPreviousResponse("There isn't a previous response to query")
 
+    def assertResponseContains(self, text, response=None, html=True, **kwargs):
+        """ Convenience wrapper for assertContains """
+        response = self._which_response(response)
+        self.assertContains(response, text, html=html, **kwargs)
+
     def get_context(self, key):
         if self.last_response is not None:
             self.assertTrue(key in self.last_response.context)

--- a/test_project/test_app/tests.py
+++ b/test_project/test_app/tests.py
@@ -266,6 +266,11 @@ class TestPlusViewTests(TestCase):
                              extra={'HTTP_X_REQUESTED_WITH': 'XMLHttpRequest'})
         self.response_200(response)
 
+    def test_assertresponsecontains(self):
+        self.get('view-contains')
+        self.assertResponseContains('<p>Hello world</p>')
+        self.assertResponseNotContains('<p>Hello Frank</p>')
+
 
 class TestPlusCBViewTests(CBVTestCase):
 

--- a/test_project/test_app/urls.py
+++ b/test_project/test_app/urls.py
@@ -6,7 +6,8 @@ except ImportError:
 from .views import (
     data_1, data_5, needs_login, view_200, view_201, view_302,
     view_400, view_401, view_403, view_404, view_405, view_410,
-    view_context_with, view_context_without, view_is_ajax, view_redirect,
+    view_contains, view_context_with, view_context_without,
+    view_is_ajax, view_redirect,
 )
 
 urlpatterns = patterns(
@@ -28,4 +29,5 @@ urlpatterns = patterns(
     url(r'^view/context/with/$', view_context_with, name='view-context-with'),
     url(r'^view/context/without/$', view_context_without, name='view-context-without'),
     url(r'^view/isajax/$', view_is_ajax, name='view-is-ajax'),
+    url(r'^view/contains/$', view_contains, name='view-contains'),
 )

--- a/test_project/test_app/views.py
+++ b/test_project/test_app/views.py
@@ -79,6 +79,10 @@ def view_is_ajax(request):
     return HttpResponse('', status=200 if request.is_ajax() else 404)
 
 
+def view_contains(request):
+    return render(request, 'test.html', {})
+
+
 # Class-based test views
 
 class CBView(generic.View):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,33,34}-dj{15,16,17,18,19}
+envlist = py{27,33,34,35}-dj{15,16,17,18},py{27,34,35}-dj{19}
 skip_missing_interpreters = True
 
 [testenv]
@@ -7,6 +7,7 @@ basepython =
     py27: python2.7
     py33: python3.3
     py34: python3.4
+    py35: python3.5
 
 deps =
     dj15: Django~=1.5.0
@@ -14,6 +15,7 @@ deps =
     dj17: Django~=1.7.0
     dj18: Django~=1.8.0
     dj19: Django~=1.9.0
+    coverage
     factory-boy
     flake8
 


### PR DESCRIPTION
A couple of convenience methods to save some typing in test cases.

    def test_response_contains(self):
        self.get('hello-world')
        self.assertResponseContains('<p>Hello, World!</p>')

    def test_response_not_contains(self):
        self.get('hello-world')
        self.assertResponseNotContains('<p>Hello, Frank!</p>')

Uses the private _which_response method and defaults html to True.