### PR TITLE
Add response_301 method to check for django.http.HttpResponsePermanentRedirect

### DIFF
--- a/docs/methods.rst
+++ b/docs/methods.rst
@@ -153,6 +153,7 @@ django-test-plus provides the following response method checks for you::
 
     - response_200()
     - response_201()
+    - response_301()
     - response_302()
     - response_400()
     - response_401()

--- a/test_plus/test.py
+++ b/test_plus/test.py
@@ -198,6 +198,11 @@ class TestCase(DjangoTestCase):
         response = self._which_response(response)
         self.assertEqual(response.status_code, 201)
 
+    def response_301(self, response=None):
+        """ Given response has status_code 301 """
+        response = self._which_response(response)
+        self.assertEqual(response.status_code, 301)
+
     def response_302(self, response=None):
         """ Given response has status_code 302 """
         response = self._which_response(response)

--- a/test_plus/test.py
+++ b/test_plus/test.py
@@ -17,6 +17,7 @@ from django.utils.functional import curry
 class NoPreviousResponse(Exception):
     pass
 
+
 # Build a real context in versions of Django greater than 1.6
 # On versions below 1.6, create a context that simply warns that
 # the query number assertion is not happening

--- a/test_project/runtests.py
+++ b/test_project/runtests.py
@@ -20,5 +20,6 @@ def runtests(*test_args):
     failures = test_runner.run_tests(['test_app'])
     sys.exit(failures)
 
+
 if __name__ == '__main__':
     runtests()

--- a/test_project/test_app/tests.py
+++ b/test_project/test_app/tests.py
@@ -224,6 +224,13 @@ class TestPlusViewTests(TestCase):
         # Test without response option
         self.response_201()
 
+    def test_response_301(self):
+        res = self.get('view-301')
+        self.response_301(res)
+
+        # Test without response option
+        self.response_301()
+
     def test_response_302(self):
         res = self.get('view-302')
         self.response_302(res)

--- a/test_project/test_app/urls.py
+++ b/test_project/test_app/urls.py
@@ -4,7 +4,7 @@ except ImportError:
     from django.conf.urls.defaults import url, include
 
 from .views import (
-    data_1, data_5, needs_login, view_200, view_201, view_302,
+    data_1, data_5, needs_login, view_200, view_201, view_301, view_302,
     view_400, view_401, view_403, view_404, view_405, view_410,
     view_contains, view_context_with, view_context_without,
     view_is_ajax, view_redirect, FormErrors
@@ -14,6 +14,7 @@ urlpatterns = [
     url(r'^accounts/', include('django.contrib.auth.urls')),
     url(r'^view/200/$', view_200, name='view-200'),
     url(r'^view/201/$', view_201, name='view-201'),
+    url(r'^view/301/$', view_301, name='view-301'),
     url(r'^view/302/$', view_302, name='view-302'),
     url(r'^view/400/$', view_400, name='view-400'),
     url(r'^view/401/$', view_401, name='view-401'),

--- a/test_project/test_app/views.py
+++ b/test_project/test_app/views.py
@@ -17,6 +17,10 @@ def view_201(request):
     return HttpResponse('', status=201)
 
 
+def view_301(request):
+    return HttpResponse('', status=301)
+
+
 def view_302(request):
     return HttpResponse('', status=302)
 


### PR DESCRIPTION
Not a particularly exciting addition, but I have a need to check a view that returns a HttpResponsePermanentRedirect response so decided to add provide this for parity with 302.