### PR TITLE
Allow custom Request for CBVTestCase.get(), .post()

### DIFF
--- a/test_plus/test.py
+++ b/test_plus/test.py
@@ -481,23 +481,29 @@ class CBVTestCase(TestCase):
         finally:
             signals.template_rendered.disconnect(dispatch_uid=signal_uid)
 
-    def get_check_200(self, cls, *args, **kwargs):
+    def get_check_200(self, url, *args, **kwargs):
         """ Test that we can GET a page and it returns a 200 """
-        initkwargs = kwargs.pop('initkwargs', None)
-        response = self.get(cls, initkwargs=initkwargs, *args, **kwargs)
+        response = super(CBVTestCase, self).get(url, *args, **kwargs)
         self.response_200(response)
         return response
 
-    def assertGoodView(self, cls, *args, **kwargs):
+    def assertLoginRequired(self, url, *args, **kwargs):
+        """ Ensure login is required to GET this URL """
+        response = super(CBVTestCase, self).get(url, *args, **kwargs)
+        reversed_url = reverse(url, args=args, kwargs=kwargs)
+        login_url = str(resolve_url(settings.LOGIN_URL))
+        expected_url = "{0}?next={1}".format(login_url, reversed_url)
+        self.assertRedirects(response, expected_url)
+
+    def assertGoodView(self, url_name, *args, **kwargs):
         """
         Quick-n-dirty testing of a given view.
         Ensures view returns a 200 status and that generates less than 50
         database queries.
         """
-        initkwargs = kwargs.pop('initkwargs', None)
         query_count = kwargs.pop('test_query_count', 50)
 
         with self.assertNumQueriesLessThan(query_count):
-            response = self.get(cls, initkwargs=initkwargs, *args, **kwargs)
+            response = super(CBVTestCase, self).get(url_name, *args, **kwargs)
         self.response_200(response)
         return response

--- a/test_plus/test.py
+++ b/test_plus/test.py
@@ -410,7 +410,8 @@ class CBVTestCase(TestCase):
         because SingleObjectMixin (part of generic.DetailView)
         expects self.object to be set before invoking get_context_data().
 
-        `args` and `kwargs` are the same values you would pass to ``reverse()``.
+        Pass a "request" kwarg in order for your tests to have particular
+        request attributes.
         """
         initkwargs = kwargs.pop('initkwargs', None)
         request = kwargs.pop('request', None)
@@ -424,34 +425,30 @@ class CBVTestCase(TestCase):
 
     def get(self, cls, *args, **kwargs):
         """
-        Calls cls.get() method after instantiating view class
-        with `initkwargs`.
+        Calls cls.get() method after instantiating view class.
         Renders view templates and sets context if appropriate.
         """
-        initkwargs = kwargs.pop('initkwargs', None)
-        if initkwargs is None:
-            initkwargs = {}
-        request = RequestFactory().get('/')
-        instance = self.get_instance(cls, initkwargs=initkwargs, request=request, **kwargs)
-        self.last_response = self.get_response(request, instance.get)
+        instance = self.get_instance(cls, *args, **kwargs)
+        if not instance.request:
+            # Use a basic request
+            instance.request = RequestFactory().get('/')
+        self.last_response = self.get_response(instance.request, instance.get)
         self.context = self.last_response.context
         return self.last_response
 
     def post(self, cls, *args, **kwargs):
         """
-        Calls cls.post() method after instantiating view class
-        with `initkwargs`.
+        Calls cls.post() method after instantiating view class.
         Renders view templates and sets context if appropriate.
         """
         data = kwargs.pop('data', None)
-        initkwargs = kwargs.pop('initkwargs', None)
         if data is None:
             data = {}
-        if initkwargs is None:
-            initkwargs = {}
-        request = RequestFactory().post('/', data)
-        instance = self.get_instance(cls, initkwargs=initkwargs, request=request, **kwargs)
-        self.last_response = self.get_response(request, instance.post)
+        instance = self.get_instance(cls, *args, **kwargs)
+        if not instance.request:
+            # Use a basic request
+            instance.request = RequestFactory().post('/', data)
+        self.last_response = self.get_response(instance.request, instance.post)
         self.context = self.last_response.context
         return self.last_response
 

--- a/test_project/test_app/forms.py
+++ b/test_project/test_app/forms.py
@@ -1,5 +1,14 @@
 from django import forms
 
+from .models import Data
+
 
 class TestNameForm(forms.Form):
     name = forms.CharField(max_length=255)
+
+
+class TestDataForm(forms.ModelForm):
+
+    class Meta:
+        model = Data
+        fields = ['name']

--- a/test_project/test_app/tests.py
+++ b/test_project/test_app/tests.py
@@ -23,8 +23,8 @@ from .forms import TestNameForm
 from .models import Data
 from .views import (
     CBDataView,
-    CBView,
     CBTemplateView,
+    CBView,
 )
 
 DJANGO_16 = LooseVersion(django.get_version()) >= LooseVersion('1.6')
@@ -343,7 +343,7 @@ class TestPlusViewTests(TestCase):
     @unittest.expectedFailure
     def test_assertnumqueries_failure(self):
         if not DJANGO_16:
-            return unittest.skip("Does not work before Django 1.6")
+            return unittest.skip('Does not work before Django 1.6')
 
         with self.assertNumQueriesLessThan(1):
             self.get('view-data-5')
@@ -351,7 +351,7 @@ class TestPlusViewTests(TestCase):
     def test_assertnumqueries_warning(self):
         if not DJANGO_16:
             with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter("always")
+                warnings.simplefilter('always')
 
                 with self.assertNumQueriesLessThan(1):
                     self.get('view-data-1')
@@ -359,7 +359,7 @@ class TestPlusViewTests(TestCase):
                 self.assertEqual(len(w), 1)
                 self.assertTrue('skipped' in str(w[-1].message))
         else:
-            return unittest.skip("Only useful for Django 1.6 and before")
+            return unittest.skip('Only useful for Django 1.6 and before')
 
     def test_assertincontext(self):
         response = self.get('view-context-with')
@@ -415,19 +415,27 @@ class TestPlusViewTests(TestCase):
 class TestPlusCBViewTests(CBVTestCase):
 
     def test_get(self):
-        response = self.get(CBView)
-        self.assertEqual(response.status_code, 200)
+        self.get(CBView)
+        self.response_200()
 
     def test_post(self):
         data = {'testing': True}
-        response = self.post(CBView, data=data)
-        self.assertEqual(response.status_code, 200)
+        self.post(CBView, data=data)
+        self.response_200()
 
     def test_get_check_200(self):
-        self.get_check_200(CBView)
+        self.get_check_200('cbview')
 
     def test_assert_good_view(self):
-        self.assertGoodView(CBView)
+        self.assertGoodView('cbview')
+
+    def test_login_required(self):
+        self.assertLoginRequired('cbview-needs-login')
+
+        # Make a user and login with our login context
+        self.make_user('test')
+        with self.login(username='test', password='password'):
+            self.get_check_200('cbview-needs-login')
 
 
 class TestPlusCBDataViewTests(CBVTestCase):
@@ -436,13 +444,13 @@ class TestPlusCBDataViewTests(CBVTestCase):
     """
 
     def setUp(self):
-        self.data = Data.objects.create(name="RevSys")
+        self.data = Data.objects.create(name='RevSys')
 
     def test_get_request_attributes(self):
         """
         Ensure custom `request` attribute is seen at view
         """
-        request = django.test.RequestFactory().get("/")
+        request = django.test.RequestFactory().get('/')
         # add custom attribute
         request.some_data = 5
 
@@ -458,14 +466,14 @@ class TestPlusCBDataViewTests(CBVTestCase):
         """
         Ensure `initkwargs` overrides view attributes
         """
-        request = django.test.RequestFactory().get("/")
+        request = django.test.RequestFactory().get('/')
 
         self.get(
             CBDataView,
             request=request,
             pk=self.data.pk,
         )
-        self.assertTemplateUsed("test.html")  # default template
+        self.assertTemplateUsed('test.html')  # default template
 
         # Use `initkwargs` to override view class "template_name" attribute
         self.get(
@@ -473,16 +481,16 @@ class TestPlusCBDataViewTests(CBVTestCase):
             request=request,
             pk=self.data.pk,
             initkwargs={
-                "template_name": "other.html",
+                'template_name': 'other.html',
             }
         )
-        self.assertTemplateUsed("other.html")  # overridden template
+        self.assertTemplateUsed('other.html')  # overridden template
 
     def test_post_request_attributes(self):
         """
         Ensure custom `request` attribute is seen at view
         """
-        request = django.test.RequestFactory().post("/")
+        request = django.test.RequestFactory().post('/')
         # add custom attribute
         request.some_data = 5
 
@@ -499,7 +507,7 @@ class TestPlusCBDataViewTests(CBVTestCase):
         """
         Ensure `initkwargs` overrides view attributes
         """
-        request = django.test.RequestFactory().post("/")
+        request = django.test.RequestFactory().post('/')
 
         self.post(
             CBDataView,
@@ -507,7 +515,7 @@ class TestPlusCBDataViewTests(CBVTestCase):
             pk=self.data.pk,
             data={}  # no data, name is required so this will be invalid
         )
-        self.assertTemplateUsed("test.html")  # default template
+        self.assertTemplateUsed('test.html')  # default template
 
         # Use `initkwargs` to override view class "template_name" attribute
         self.post(
@@ -515,11 +523,11 @@ class TestPlusCBDataViewTests(CBVTestCase):
             request=request,
             pk=self.data.pk,
             initkwargs={
-                "template_name": "other.html",
+                'template_name': 'other.html',
             },
             data={}  # no data, name is required so this will be invalid
         )
-        self.assertTemplateUsed("other.html")  # overridden template
+        self.assertTemplateUsed('other.html')  # overridden template
 
 
 class TestPlusCBTemplateViewTests(CBVTestCase):

--- a/test_project/test_app/urls.py
+++ b/test_project/test_app/urls.py
@@ -8,6 +8,7 @@ from .views import (
     view_302, view_400, view_401, view_403, view_404, view_405, view_410,
     view_contains, view_context_with, view_context_without, view_headers,
     view_is_ajax, view_redirect,
+    CBLoginRequiredView, CBView,
 )
 
 urlpatterns = [
@@ -32,4 +33,6 @@ urlpatterns = [
     url(r'^view/contains/$', view_contains, name='view-contains'),
     url(r'^view/form-errors/$', FormErrors.as_view(), name='form-errors'),
     url(r'^view/headers/$', view_headers, name='view-headers'),
+    url(r'^cbview/needs-login/$', CBLoginRequiredView.as_view(), name='cbview-needs-login'),
+    url(r'^cbview/$', CBView.as_view(), name='cbview'),
 ]

--- a/test_project/test_app/views.py
+++ b/test_project/test_app/views.py
@@ -2,6 +2,7 @@ from django.contrib.auth.decorators import login_required
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse, HttpResponseGone
 from django.shortcuts import redirect, render
+from django.utils.decorators import method_decorator
 from django.views import generic
 
 from .forms import TestDataForm, TestNameForm
@@ -110,6 +111,16 @@ class CBView(generic.View):
             return self.special_value
         else:
             return False
+
+
+class CBLoginRequiredView(generic.View):
+
+    @method_decorator(login_required)
+    def dispatch(self, *args, **kwargs):
+        return super(CBLoginRequiredView, self).dispatch(*args, **kwargs)
+
+    def get(self, request):
+        return HttpResponse('', status=200)
 
 
 class CBDataView(generic.UpdateView):

--- a/test_project/test_app/views.py
+++ b/test_project/test_app/views.py
@@ -1,9 +1,10 @@
 from django.contrib.auth.decorators import login_required
+from django.core.urlresolvers import reverse
 from django.http import HttpResponse, HttpResponseGone
-from django.shortcuts import render, redirect
+from django.shortcuts import redirect, render
 from django.views import generic
 
-from .forms import TestNameForm
+from .forms import TestDataForm, TestNameForm
 from .models import Data
 
 
@@ -109,6 +110,24 @@ class CBView(generic.View):
             return self.special_value
         else:
             return False
+
+
+class CBDataView(generic.UpdateView):
+
+    model = Data
+    template_name = "test.html"
+    form_class = TestDataForm
+
+    def get_success_url(self):
+        return reverse("view-200")
+
+    def get_context_data(self, **kwargs):
+        kwargs = super(CBDataView, self).get_context_data(**kwargs)
+        if hasattr(self.request, "some_data"):
+            kwargs.update({
+                "some_data": self.request.some_data
+            })
+        return kwargs
 
 
 class CBTemplateView(generic.TemplateView):


### PR DESCRIPTION
This update refactors CBVTestCase.get_instance(), .get(), and .post() in order to allow use of custom Request objects in CBVTestCase.get() and .post().

Often a view method needs to reference `request.user` or some other special attribute. Now testers can create a request from RequestFactory, assign the attribute(s) needed, and pass the request to .get() or .post().

This PR does not change current behavior. If no `request` is passed to .get() or .post(), an empty Request instance is created and used just like before.