### PR TITLE
Replace deprecated import

### DIFF
--- a/test_plus/test.py
+++ b/test_plus/test.py
@@ -4,7 +4,7 @@ import django
 from django.conf import settings
 from django.contrib.auth.models import Permission
 from django.core.exceptions import ImproperlyConfigured
-from django.core.urlresolvers import reverse, NoReverseMatch
+from django.urls import reverse, NoReverseMatch
 from django.shortcuts import resolve_url
 from django.db import connections, DEFAULT_DB_ALIAS
 from django.db.models import Q

--- a/test_plus/test.py
+++ b/test_plus/test.py
@@ -4,7 +4,7 @@ import django
 from django.conf import settings
 from django.contrib.auth.models import Permission
 from django.core.exceptions import ImproperlyConfigured
-from django.urls import reverse, NoReverseMatch
+from django.conf.urls import reverse, NoReverseMatch
 from django.shortcuts import resolve_url
 from django.db import connections, DEFAULT_DB_ALIAS
 from django.db.models import Q


### PR DESCRIPTION
RemovedInDjango20Warning: Importing from django.core.urlresolvers is deprecated in favor of django.urls.
  from django.core.urlresolvers import reverse, NoReverseMatch