### PR TITLE
:fire: Drop Python 3.3 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ python:
 install:
   - pip install -e .
   - pip install $DJANGO
-  - pip install -r requirements-travisci.txt
-  - pip install coveralls flake8
+  - pip install -r requirements-dev.txt
 script:
   - flake8 . --ignore=E501,E402
   - coverage run --source=test_plus setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
@@ -29,15 +28,6 @@ matrix:
   exclude:
     # Django>=2.0 doesn't support Python 2.7
     - python: "2.7"
-      env: DJANGO="Django<2.1"
-    # Django>=1.9 doesn't support Python 3.3
-    - python: "3.3"
-      env: DJANGO="Django<1.10"
-    - python: "3.3"
-      env: DJANGO="Django<1.11"
-    - python: "3.3"
-      env: DJANGO="Django<1.12"
-    - python: "3.3"
       env: DJANGO="Django<2.1"
     # Django<1.8 doesn't support Python 3.5
     - python: "3.5"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,9 @@
-# These requirements are necessary for working on the django-test-plus
-# project itself.  They are not necessary for running the tests or
-# using the library.
--r requirements-travisci.txt
+# These requirements are necessary for developing the django-test-plus
+# project itself.
 
-pypandoc==0.9.7
+-r requirements.txt
+
+coveralls==1.2.0
+factory-boy==2.5.2
+flake8==3.4.1
+pypandoc==1.4

--- a/requirements-travisci.txt
+++ b/requirements-travisci.txt
@@ -1,5 +1,0 @@
-# Requirements necessary for running the tests
--r requirements.txt
-
-factory-boy==2.5.2
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-Django>=1.4.20
+Django>1.5

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
     py{27}-dj{15,16,17,18,19,110,111}
-    py{33}-dj{15,16,17,18}
     py{34}-dj{15,16,17,18,19,110,111,20}
     py{35}-dj{18,19,110,111,20}
     py{36}-dj{111,20}
@@ -11,7 +10,6 @@ skip_missing_interpreters = True
 [testenv]
 basepython =
     py27: python2.7
-    py33: python3.3
     py34: python3.4
     py35: python3.5
     py36: python3.6


### PR DESCRIPTION
Since Python 3.3 is no longer maintained and it's usage is next to nothing, we might as well speed up our test suite by dropping support for it. See notes here for how small it's usage was a year+ ago: https://github.com/pypa/pip/issues/3796 