### PR TITLE
:fire: Drop Django <1.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ script:
 after_success:
   - coveralls
 env:
-  - DJANGO="Django<1.6"
-  - DJANGO="Django<1.7"
   - DJANGO="Django<1.8"
   - DJANGO="Django<1.9"
   - DJANGO="Django<1.10"
@@ -29,17 +27,3 @@ matrix:
     # Django>=2.0 doesn't support Python 2.7
     - python: "2.7"
       env: DJANGO="Django<2.1"
-    # Django<1.8 doesn't support Python 3.5
-    - python: "3.5"
-      env: DJANGO="Django<1.6"
-    - python: "3.5"
-      env: DJANGO="Django<1.7"
-    - python: "3.5"
-      env: DJANGO="Django<1.8"
-    # Django<1.8 doesn't support Python 3.6
-    - python: "3.6"
-      env: DJANGO="Django<1.6"
-    - python: "3.6"
-      env: DJANGO="Django<1.7"
-    - python: "3.6"
-      env: DJANGO="Django<1.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ script:
 after_success:
   - coveralls
 env:
-  - DJANGO="Django<1.8"
   - DJANGO="Django<1.9"
   - DJANGO="Django<1.10"
   - DJANGO="Django<1.11"

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Support
 
 Supports: Python 2 and Python 3
 
-Supports Django Versions: 1.5, 1.6, 1.7, 1.8, 1.9, 1.10, 1.11, 2.0
+Supports Django Versions: 1.8, 1.9, 1.10, 1.11, 2.0
 
 Documentation
 --------------

--- a/README.rst
+++ b/README.rst
@@ -231,9 +231,6 @@ method will create a user for you::
         user1 = self.make_user('u1')
         user2 = self.make_user('u2')
 
-**NOTE:** This work properly with version of Django prior to 1.6 and
-will use your own User class if you have created your own User model.
-
 If creating a User in your project is more complicated, say for example
 you removed the ``username`` field from the default Django Auth model
 you can provide a `Factory
@@ -357,10 +354,6 @@ more queries than you expect::
         with self.assertNumQueriesLessThan(7):
             self.get('some-view-with-6-queries')
 
-
-**NOTE:** This isn't possible in versions of Django prior to 1.6, so the
-context will run your code and assertions and issue a warning that it
-cannot check the number of queries generated.
 
 assertGoodView(url\_name, \*args, \*\*kwargs)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/low_query_counts.rst
+++ b/docs/low_query_counts.rst
@@ -17,10 +17,6 @@ more queries than you expect::
             self.get('some-view-with-6-queries')
 
 
-**NOTE:** This isn't possible in versions of Django prior to 1.6, so the
-context will run your code and assertions and issue a warning that it
-cannot check the number of queries generated.
-
 assertGoodView(url\_name, \*args, \*\*kwargs)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/methods.rst
+++ b/docs/methods.rst
@@ -236,9 +236,6 @@ method will create a user for you::
         user1 = self.make_user('u1')
         user2 = self.make_user('u2')
 
-**NOTE:** This work properly with version of Django prior to 1.6 and
-will use your own User class if you have created your own User model.
-
 If creating a User in your project is more complicated, say for example
 you removed the ``username`` field from the default Django Auth model
 you can provide a `Factory

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-Django>1.5
+Django>=1.8

--- a/setup.py
+++ b/setup.py
@@ -29,12 +29,21 @@ setup(
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
+        'Framework :: Django',
+        'Framework :: Django :: 1.8',
+        'Framework :: Django :: 1.9',
+        'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Framework :: Django',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     test_suite='runtests.runtests'
 )

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,7 @@ setup(
     include_package_data=True,
     packages=find_packages(),
     zip_safe=False,
-    install_requires=['Django>=1.5'],
     tests_require=[
-        'Django>=1.5',
         'factory-boy>=2.5.2',
     ],
     classifiers=[

--- a/test_plus/compat.py
+++ b/test_plus/compat.py
@@ -1,4 +1,1 @@
-try:
-    from django.urls import reverse, NoReverseMatch
-except ImportError:
-    from django.core.urlresolvers import reverse, NoReverseMatch  # noqa
+from django.core.urlresolvers import reverse, NoReverseMatch  # noqa

--- a/test_plus/runner.py
+++ b/test_plus/runner.py
@@ -2,10 +2,8 @@
 from __future__ import unicode_literals
 
 import logging
-try:
-    from django.test.runner import DiscoverRunner as DefaultRunner
-except ImportError:
-    from django.test.simple import DjangoTestSuiteRunner as DefaultRunner
+
+from django.test.runner import DiscoverRunner as DefaultRunner
 
 
 class NoLoggingRunner(DefaultRunner):

--- a/test_plus/test.py
+++ b/test_plus/test.py
@@ -1,15 +1,13 @@
-import warnings
-
-import django
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.core.exceptions import ImproperlyConfigured
-from django.shortcuts import resolve_url
 from django.db import connections, DEFAULT_DB_ALIAS
 from django.db.models import Q
-from distutils.version import LooseVersion
+from django.shortcuts import resolve_url
 from django.test import RequestFactory, signals, TestCase as DjangoTestCase
 from django.test.client import store_rendered_templates
+from django.test.utils import CaptureQueriesContext
 from django.utils.functional import curry
 
 from .compat import reverse, NoReverseMatch
@@ -19,48 +17,29 @@ class NoPreviousResponse(Exception):
     pass
 
 
-# Build a real context in versions of Django greater than 1.6
-# On versions below 1.6, create a context that simply warns that
-# the query number assertion is not happening
-if LooseVersion(django.get_version()) >= LooseVersion('1.6'):
-    from django.test.utils import CaptureQueriesContext
-    from django.contrib.auth import get_user_model
+# Build a real context
 
-    User = get_user_model()
+User = get_user_model()
 
-    CAPTURE = True
+CAPTURE = True
 
-    class _AssertNumQueriesLessThanContext(CaptureQueriesContext):
-        def __init__(self, test_case, num, connection):
-            self.test_case = test_case
-            self.num = num
-            super(_AssertNumQueriesLessThanContext, self).__init__(connection)
 
-        def __exit__(self, exc_type, exc_value, traceback):
-            super(_AssertNumQueriesLessThanContext, self).__exit__(exc_type, exc_value, traceback)
-            if exc_type is not None:
-                return
-            executed = len(self)
-            self.test_case.assertTrue(
-                executed < self.num, "%d queries executed, expected less than %d" % (
-                    executed, self.num
-                )
+class _AssertNumQueriesLessThanContext(CaptureQueriesContext):
+    def __init__(self, test_case, num, connection):
+        self.test_case = test_case
+        self.num = num
+        super(_AssertNumQueriesLessThanContext, self).__init__(connection)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super(_AssertNumQueriesLessThanContext, self).__exit__(exc_type, exc_value, traceback)
+        if exc_type is not None:
+            return
+        executed = len(self)
+        self.test_case.assertTrue(
+            executed < self.num, "%d queries executed, expected less than %d" % (
+                executed, self.num
             )
-
-else:
-    from django.contrib.auth.models import User
-
-    CAPTURE = False
-
-    class _AssertNumQueriesLessThanContext(object):
-        def __init__(self, test_case, num, connection):
-            pass
-
-        def __enter__(self):
-            pass
-
-        def __exit__(self, exc_type, exc_value, traceback):
-            warnings.warn("assertNumQueriesLessThan being skipped, does not work prior to Django 1.6")
+        )
 
 
 class login(object):

--- a/test_project/test_app/tests.py
+++ b/test_project/test_app/tests.py
@@ -1,12 +1,10 @@
 import django
 import factory
+import sys
 import unittest
-import warnings
 
 from contextlib import contextmanager
-from distutils.version import LooseVersion
-
-import sys
+from django.contrib.auth import get_user_model
 
 try:
     from StringIO import StringIO
@@ -27,13 +25,8 @@ from .views import (
     CBView,
 )
 
-DJANGO_16 = LooseVersion(django.get_version()) >= LooseVersion('1.6')
 
-if DJANGO_16:
-    from django.contrib.auth import get_user_model
-    User = get_user_model()
-else:
-    from django.contrib.auth.models import User
+User = get_user_model()
 
 
 @contextmanager
@@ -342,24 +335,8 @@ class TestPlusViewTests(TestCase):
 
     @unittest.expectedFailure
     def test_assertnumqueries_failure(self):
-        if not DJANGO_16:
-            return unittest.skip('Does not work before Django 1.6')
-
         with self.assertNumQueriesLessThan(1):
             self.get('view-data-5')
-
-    def test_assertnumqueries_warning(self):
-        if not DJANGO_16:
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter('always')
-
-                with self.assertNumQueriesLessThan(1):
-                    self.get('view-data-1')
-
-                self.assertEqual(len(w), 1)
-                self.assertTrue('skipped' in str(w[-1].message))
-        else:
-            return unittest.skip('Only useful for Django 1.6 and before')
 
     def test_assertincontext(self):
         response = self.get('view-context-with')

--- a/test_project/test_project/settings.py
+++ b/test_project/test_project/settings.py
@@ -22,8 +22,6 @@ SECRET_KEY = 'mlqc(f8*woj%&b(gf=al7yc8$v3+(b8-=k&50%vyao8p5u8b6*'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-TEMPLATE_DEBUG = True
-
 ALLOWED_HOSTS = []
 
 
@@ -63,11 +61,6 @@ DATABASES = {
     }
 }
 
-# For Django <1.10
-TEMPLATE_DIRS = (
-    os.path.join(BASE_DIR, 'test_project/templates'),
-)
-
 # For Django 1.10+
 TEMPLATES = [
     {
@@ -83,6 +76,7 @@ TEMPLATES = [
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
             ],
+            'debug': True
         }
     }
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{27}-dj{15,16,17,18,19,110,111}
-    py{34}-dj{15,16,17,18,19,110,111,20}
+    py{27}-dj{18,19,110,111}
+    py{34}-dj{18,19,110,111,20}
     py{35}-dj{18,19,110,111,20}
     py{36}-dj{111,20}
 
@@ -15,9 +15,6 @@ basepython =
     py36: python3.6
 
 deps =
-    dj15: Django<1.6
-    dj16: Django<1.7
-    dj17: Django<1.8
     dj18: Django<1.9
     dj19: Django<1.10
     dj110: Django<1.11


### PR DESCRIPTION
In theory, nothing has changed which will prevent older versions from working internally. However, we want to set a reasonable standard for which versions to update for yet keep our testsuite running quickly. 

Fixes #62 