### PR TITLE
Really test Django 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,30 +6,10 @@ python:
   - "3.6"
 
 install:
-  - pip install -e .
-  - pip install $DJANGO || pip install --pre $DJANGO
+  - pip install tox-travis
   - pip install -r requirements-dev.txt
-  - if [ -z ${DRF+x} ]; then echo "no drf"; else pip install djangorestframework; fi
 script:
   - flake8 . --ignore=E501,E402
-  - coverage run --source=test_plus setup.py test
+  - tox
 after_success:
   - coveralls
-env:
-  - DJANGO="Django<1.9"
-  - DJANGO="Django<1.10"
-  - DJANGO="Django<1.11"
-  - DJANGO="Django<1.12"
-  - DJANGO="Django>=2.0a1,<2.1"
-
-  - DJANGO="Django<1.9" DRF=1
-  - DJANGO="Django<1.10" DRF=1
-  - DJANGO="Django<1.11" DRF=1
-  - DJANGO="Django<1.12" DRF=1
-  - DJANGO="Django>=2.0a1,<2.1" DRF=1
-
-matrix:
-  exclude:
-    # Django>=2.0 doesn't support Python 2.7
-    - python: "2.7"
-      env: DJANGO=">=2.0a1,<2.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 
 install:
   - pip install -e .
-  - pip install $DJANGO
+  - pip install $DJANGO || pip install --pre $DJANGO
   - pip install -r requirements-dev.txt
   - if [ -z ${DRF+x} ]; then echo "no drf"; else pip install djangorestframework; fi
 script:
@@ -20,16 +20,16 @@ env:
   - DJANGO="Django<1.10"
   - DJANGO="Django<1.11"
   - DJANGO="Django<1.12"
-  - DJANGO="Django<2.1"
+  - DJANGO="Django>=2.0a1,<2.1"
 
   - DJANGO="Django<1.9" DRF=1
   - DJANGO="Django<1.10" DRF=1
   - DJANGO="Django<1.11" DRF=1
   - DJANGO="Django<1.12" DRF=1
-  - DJANGO="Django<2.1" DRF=1
+  - DJANGO="Django>=2.0a1,<2.1" DRF=1
 
 matrix:
   exclude:
     # Django>=2.0 doesn't support Python 2.7
     - python: "2.7"
-      env: DJANGO="Django<2.1"
+      env: DJANGO=">=2.0a1,<2.1"

--- a/test_plus/compat.py
+++ b/test_plus/compat.py
@@ -1,10 +1,14 @@
-from django.core.exceptions import ImproperlyConfigured
-from django.core.urlresolvers import reverse, NoReverseMatch  # noqa
+try:
+    from django.urls import reverse, NoReverseMatch
+except ImportError:
+    from django.core.urlresolvers import reverse, NoReverseMatch  # noqa
 
 try:
     from rest_framework.test import APIClient
     DRF = True
 except ImportError:
+    from django.core.exceptions import ImproperlyConfigured
+
     def APIClient(*args, **kwargs):
         raise ImproperlyConfigured('django-rest-framework must be installed in order to use APITestCase.')
     DRF = False

--- a/test_project/test_app/views.py
+++ b/test_project/test_app/views.py
@@ -1,7 +1,6 @@
 import json
 
 from django.contrib.auth.decorators import login_required
-from django.core.urlresolvers import reverse
 from django.http import HttpResponse, HttpResponseGone
 from django.shortcuts import redirect, render
 from django.utils.decorators import method_decorator
@@ -9,6 +8,11 @@ from django.views import generic
 
 from .forms import TestDataForm, TestNameForm
 from .models import Data
+
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 
 
 # Function-based test views

--- a/test_project/test_project/settings.py
+++ b/test_project/test_project/settings.py
@@ -37,7 +37,7 @@ INSTALLED_APPS = (
     'test_app',
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -45,6 +45,9 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
+
+# Backwards compatibility for Django < 1.10
+MIDDLEWARE_CLASSES = MIDDLEWARE
 
 ROOT_URLCONF = 'test_app.urls'
 

--- a/tox.ini
+++ b/tox.ini
@@ -23,10 +23,13 @@ deps =
     dj19: Django<1.10
     dj110: Django<1.11
     dj111: Django<2.0
-    dj20: Django<2.1
+    dj20: Django>=2.0a1,<2.1
     drf: djangorestframework
     coverage
     factory-boy
+
+pip_pre =
+    dj20: True
 
 commands =
     coverage run --source=test_plus setup.py test


### PR DESCRIPTION
Re-opened solution for #65.

After realising why things were failing in travis (exclusion was not working as expected) I decided to substitute defining the build matrix in `.travis.yml` and instead defer that duty to `tox`.

There is (demonstrably) a maintenance burden associated with making travis play nicely with what is already defined in `tox.ini`. Applying DRY to the CI seems like the right thing to do to solve that, and it shouldn't result in any surprises for the next developer who has locally run the test suite with a success, only to have it fail in travis.