### PR TITLE
Add response_### methods back to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Django-test-plus provides a majority of the status codes assertions for you. The
 can be found in their own [mixin](https://github.com/revsys/django-test-plus/blob/master/test_plus/status_codes.py)
 and should be searchable if you're using an IDE like pycharm. It should be noted that in previous
 versions, django-test-plus had assertion methods in the pattern of `response_###()`, which are still
-available but have since been deprecated. 
+available but have since been deprecated. See below for a list of those methods. 
 
 Each of the assertion methods takes an optional Django test client `response` and a string `msg` argument
 that, if specified, is used as the error message when a failure occurs. The methods,
@@ -248,6 +248,22 @@ def test_status(self):
 ```
 
 Which is a bit shorter.
+
+The `response_###()` methods that are deprecated, but still available for use, include: 
+
+- `response_200()`
+- `response_201()` 
+- `response_204()` 
+- `response_301()`
+- `response_302()` 
+- `response_400()`
+- `response_401()` 
+- `response_403()`
+- `response_404()` 
+- `response_405()`
+- `response_410()` 
+
+All of which take an optional Django test client response and a str msg argument that, if specified, is used as the error message when a failure occurs. Just like the `assert_http_###_<status_name>()` methods, these methods will use the last response if it's available. 
 
 ## get_check_200(url_name, *args, **kwargs)
 

--- a/docs/methods.rst
+++ b/docs/methods.rst
@@ -148,7 +148,7 @@ With django-test-plus you can shorten that to be::
         response = self.get('my-url-name')
         self.assert_http_200_ok(response)
 
-Django-test-plus provides a majority of the status codes assertions for you. The status assertions can be found in their own `mixin <https://github.com/revsys/django-test-plus/blob/master/test_plus/status_codes.py>`__ and should be searchable if you're using an IDE like pycharm. It should be noted that in previous versions, django-test-plus had assertion methods in the pattern of ``response_###()``, which are still available but have since been deprecated. 
+Django-test-plus provides a majority of the status codes assertions for you. The status assertions can be found in their own `mixin <https://github.com/revsys/django-test-plus/blob/master/test_plus/status_codes.py>`__ and should be searchable if you're using an IDE like pycharm. It should be noted that in previous versions, django-test-plus had assertion methods in the pattern of ``response_###()``, which are still available but have since been deprecated. See below for a list of those methods. 
 
 Each of the assertion methods takes an optional Django test client ``response`` and a string ``msg`` argument that, if specified, is used as the error message when a failure occurs. The methods, ``assert_http_301_moved_permanently`` and ``assert_http_302_found`` also take an optional ``url`` argument that if passed, will check to make sure the ``response.url`` matches.
 
@@ -159,6 +159,22 @@ If it's available, the ``assert_http_###_<status_name>`` methods will use the la
         self.assert_http_200_ok()
 
 Which is a bit shorter.
+
+The ``response_###()`` methods that are deprecated, but still available for use, include: 
+
+- ``response_200()``
+- ``response_201()``
+- ``response_204()`` 
+- ``response_301()``
+- ``response_302()`` 
+- ``response_400()``
+- ``response_401()`` 
+- ``response_403()``
+- ``response_404()`` 
+- ``response_405()``
+- ``response_410()`` 
+
+All of which take an optional Django test client response and a str msg argument that, if specified, is used as the error message when a failure occurs. Just like the ``assert_http_###_<status_name>()`` methods, these methods will use the last response if it's available. 
 
 assertResponseContains(text, response=None, html=True)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Closes #104 

Based on this PR: https://github.com/revsys/django-test-plus/commit/abb8a252f14d9546d7ef79fc75cbbc1108d24878, I added the list of `response_NNN` methods back to the README. I also found the right spot in `methods.rst` and added the same text there. 