### PR TITLE
:arrow_up: Bumps tests for Django 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
-  - "3.8-dev"
+  - "3.8"
   - "pypy"
   - "pypy3"
 cache: pip

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         "Framework :: Django :: 2.0",
         "Framework :: Django :: 2.1",
         "Framework :: Django :: 2.2",
+        "Framework :: Django :: 3.0",
         "Framework :: Pytest",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,10 @@ envlist =
     py{27,py}-{1.11,1.11-drf}
     py34-{1.11,2.0}
     py34-{1.11,2.0}-drf
-    py{35,36,37,38,py3}-{1.11,2.0,2.1,latest}
-    py{35,36,37,38,py3}-{1.11,2.0,2.1,latest}-drf
+    py35-{1.11,2.0,2.1,latest}
+    py35-{1.11,2.0,2.1,latest}-drf
+    py{36,37,38,py3}-{1.11,2.0,2.1,3.0,latest}
+    py{36,37,38,py3}-{1.11,2.0,2.1,3.0,latest}-drf
 
 skip_missing_interpreters = True
 
@@ -21,6 +23,7 @@ deps =
     1.11: Django<2.0
     2.0: Django>=2.0,<2.1
     2.1: Django>=2.1,<2.2
+    3.0: Django>=3.0,<3.1
     latest: Django
     drf: djangorestframework
     factory-boy

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,12 @@ envlist =
     py{27,py}-{1.11,1.11-drf}
     py34-{1.11,2.0}
     py34-{1.11,2.0}-drf
-    py35-{1.11,2.0,2.1,latest}
-    py35-{1.11,2.0,2.1,latest}-drf
-    py{36,37,38,py3}-{1.11,2.0,2.1,3.0,latest}
-    py{36,37,38,py3}-{1.11,2.0,2.1,3.0,latest}-drf
+    py35-{1.11,2.0,2.1,2.2}
+    py35-{1.11,2.0,2.1,2.2}-drf
+    py{36,37,38,py3}-{1.11,2.0,2.1,2.2,3.0,latest}
+    py{36,37,38,py3}-{1.11,2.0,2.1,2.2,3.0,latest}-drf
+    py{36,37,38,py3}-{1.11,2.0,2.1,2.2,3.0,latest}
+    py{36,37,38,py3}-{1.11,2.0,2.1,2.2,3.0,latest}-drf
 
 skip_missing_interpreters = True
 
@@ -23,6 +25,7 @@ deps =
     1.11: Django<2.0
     2.0: Django>=2.0,<2.1
     2.1: Django>=2.1,<2.2
+    2.2: Django>=2.2,<3.0
     3.0: Django>=3.0,<3.1
     latest: Django
     drf: djangorestframework


### PR DESCRIPTION
Updates tests, setup.py, and CI to fully test Django 2.2, 3.0, and Python 3.8. 

Related to #113 and #110 