### PR TITLE
:arrow_up: Bumps project up to Django 3.2

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-Django<3.2
+Django<4.0
 factory-boy
 flake8
 pyflakes

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ attrs==21.2.0
     # via pytest
 coverage[toml]==5.5
     # via pytest-cov
-django==3.1.11
+django==3.2.3
     # via -r requirements.in
 factory-boy==3.2.0
     # via -r requirements.in

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         "Framework :: Django :: 2.2",
         "Framework :: Django :: 3.0",
         "Framework :: Django :: 3.1",
+        "Framework :: Django :: 3.2",
         "Framework :: Pytest",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,10 @@
 envlist =
     py35-{2.0,2.1,2.2}
     py35-{2.0,2.1,2.2}-drf
-    py{36,37,py3}-{2.0,2.1,2.2,3.0,3.1,latest}
-    py{36,37,py3}-{2.0,2.1,2.2,3.0,3.1,latest}-drf
-    py{38,39}-{2.2,3.0,3.1,latest}
-    py{38,39}-{2.2,3.0,3.1,latest}-drf
+    py{36,37,py3}-{2.0,2.1,2.2,3.0,3.1,3.2,latest}
+    py{36,37,py3}-{2.0,2.1,2.2,3.0,3.1,3.2,latest}-drf
+    py{38,39}-{2.2,3.0,3.1,3.2,latest}
+    py{38,39}-{2.2,3.0,3.1,3.2,latest}-drf
 
 skip_missing_interpreters = True
 
@@ -23,6 +23,7 @@ deps =
     2.2: Django>=2.2,<3.0
     3.0: Django>=3.0,<3.1
     3.1: Django>=3.1,<3.2
+    3.2: Django>=3.2,<4.0
     latest: Django
     drf: djangorestframework
     factory-boy


### PR DESCRIPTION
Bumps project up to support Django 3.2. 

In theory, this as already done with the `latest` check, but fixes trove classifiers, etc. 