### PR TITLE
Fix CBVTest example code block indentation

### DIFF
--- a/docs/cbvtestcase.rst
+++ b/docs/cbvtestcase.rst
@@ -87,7 +87,7 @@ TestCase assertion methods work with ``CBVTestCase.get()``.
 
 If you need special request attributes, i.e. 'user', you can create a
 custom Request with RequestFactory, assign to ``request.user``,
-and use that in the ``get()``:
+and use that in the ``get()``::
 
     def test_request_attribute(self):
         request = django.test.RequestFactory().get('/')
@@ -116,7 +116,7 @@ TestCase assertion methods work with ``CBVTestCase.post()``.
 
 If you need special request attributes, i.e. 'user', you can create a
 custom Request with RequestFactory, assign to ``request.user``,
-and use that in the ``post()``:
+and use that in the ``post()``::
 
     def test_request_attribute(self):
         request = django.test.RequestFactory().post('/')

--- a/docs/cbvtestcase.rst
+++ b/docs/cbvtestcase.rst
@@ -89,11 +89,11 @@ If you need special request attributes, i.e. 'user', you can create a
 custom Request with RequestFactory, assign to ``request.user``,
 and use that in the ``get()``:
 
-        def test_request_attribute(self):
-            request = django.test.RequestFactory().get('/')
-            request.user = some_user
-            self.get(MyViewClass, request=request, pk=data.pk)
-            self.assertContext('user', some_user)
+    def test_request_attribute(self):
+        request = django.test.RequestFactory().get('/')
+        request.user = some_user
+        self.get(MyViewClass, request=request, pk=data.pk)
+        self.assertContext('user', some_user)
 
 **NOTE:** This method bypasses Django's middleware, and therefore context
 variables created by middleware are not available. If this affects your
@@ -118,11 +118,11 @@ If you need special request attributes, i.e. 'user', you can create a
 custom Request with RequestFactory, assign to ``request.user``,
 and use that in the ``post()``:
 
-        def test_request_attribute(self):
-            request = django.test.RequestFactory().post('/')
-            request.user = some_user
-            self.post(MyViewClass, request=request, pk=self.data.pk, data={})
-            self.assertContext('user', some_user)
+    def test_request_attribute(self):
+        request = django.test.RequestFactory().post('/')
+        request.user = some_user
+        self.post(MyViewClass, request=request, pk=self.data.pk, data={})
+        self.assertContext('user', some_user)
 
 **NOTE:** This method bypasses Django's middleware, and therefore context
 variables created by middleware are not available. If this affects your


### PR DESCRIPTION
Two code block examples are not recognized as code blocks because they have two levels of indent:

<img width="955" alt="Screen Shot 2022-12-06 at 6 52 31 PM" src="https://user-images.githubusercontent.com/130456/206068383-fe0f82dc-d3a2-4950-bed8-d1907ad38158.png">

This PR _should_ fix that formatting by removing one level of indent. Although I haven't seen the result rendered locally (just on github, "View file"), I'm following the same convention seen in the rest of DTP documentation, one level of indent.

I didn't add the ReST code-block syntax since the existing DTP documentation does not use that format.

```
..  code-block:: php
```

The result:
<img width="1021" alt="Screen Shot 2022-12-06 at 7 04 48 PM" src="https://user-images.githubusercontent.com/130456/206069866-dd6b288c-dbe1-4c25-acf1-b9afab270003.png">

