### PR TITLE
APITestcase object requests should default to JSON

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -19,8 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.6"
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -19,6 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
+          - "3.6"
+          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/test_plus/test.py
+++ b/test_plus/test.py
@@ -387,10 +387,6 @@ class APITestCase(TestCase):
     def request(self, method, url_name, *args, **kwargs):
         data = kwargs.get("data")
         kwargs["data"] = json.dumps(data) if data is not None else None
-        kwargs["extra"] = {
-            "content_type": "application/json",
-            "HTTP_X_REQUESTED_WITH": "XMLHttpRequest",
-        }
         return getattr(self, method)(url_name, *args, **kwargs)
 
     def post(self, url_name, *args, **kwargs):

--- a/test_plus/test.py
+++ b/test_plus/test.py
@@ -1,3 +1,5 @@
+import json
+
 import django
 
 from distutils.version import LooseVersion
@@ -380,6 +382,28 @@ class APITestCase(TestCase):
     def __init__(self, *args, **kwargs):
         self.client_class = get_api_client()
         super(APITestCase, self).__init__(*args, **kwargs)
+
+    # APITest requests now default to JSON
+    def request(self, method, url_name, *args, **kwargs):
+        data = kwargs.get("data")
+        kwargs["data"] = json.dumps(data) if data is not None else None
+        kwargs["extra"] = {
+            "content_type": "application/json",
+            "HTTP_X_REQUESTED_WITH": "XMLHttpRequest",
+        }
+        return getattr(self, method)(url_name, *args, **kwargs)
+
+    def post(self, url_name, *args, **kwargs):
+        return self.request("post", url_name, *args, **kwargs)
+
+    def get(self, url_name, *args, **kwargs):
+        return self.request("get", url_name, *args, **kwargs)
+
+    def put(self, url_name, *args, **kwargs):
+        return self.request("put", url_name, *args, **kwargs)
+
+    def delete(self, url_name, *args, **kwargs):
+        return self.request("delete", url_name, *args, **kwargs)
 
 
 # Note this class inherits from TestCase defined above.

--- a/test_plus/test.py
+++ b/test_plus/test.py
@@ -385,21 +385,14 @@ class APITestCase(TestCase):
 
     # APITest requests now default to JSON
     def request(self, method, url_name, *args, **kwargs):
-        data = kwargs.get("data")
+        data = kwargs.pop("data", {})
+        extra = kwargs.pop("extra", {})
         kwargs["data"] = json.dumps(data) if data is not None else None
-        return getattr(self, method)(url_name, *args, **kwargs)
-
-    def post(self, url_name, *args, **kwargs):
-        return self.request("post", url_name, *args, **kwargs)
-
-    def get(self, url_name, *args, **kwargs):
-        return self.request("get", url_name, *args, **kwargs)
-
-    def put(self, url_name, *args, **kwargs):
-        return self.request("put", url_name, *args, **kwargs)
-
-    def delete(self, url_name, *args, **kwargs):
-        return self.request("delete", url_name, *args, **kwargs)
+        if extra and "format" in extra:
+            extra.pop("format")
+        extra.update({"content_type": "application/json"})
+        kwargs["extra"] = extra
+        return super().request(method, url_name, *args, **kwargs)
 
 
 # Note this class inherits from TestCase defined above.

--- a/test_plus/test.py
+++ b/test_plus/test.py
@@ -400,11 +400,7 @@ class APITestCase(TestCase):
             content_type = None
 
         # DRF wants either `format` or `content_type` but not both
-        if format and content_type:
-            extra.update({"content_type": "application/json"})
-        elif content_type:
-            extra.update({"content_type": "application/json"})
-        elif format:
+        if format and content_type is None:
             extra.update({"format": "json"})
         else:
             extra.update({"content_type": "application/json"})

--- a/test_plus/test.py
+++ b/test_plus/test.py
@@ -388,9 +388,27 @@ class APITestCase(TestCase):
         data = kwargs.pop("data", {})
         extra = kwargs.pop("extra", {})
         kwargs["data"] = json.dumps(data) if data is not None else None
+
         if extra and "format" in extra:
-            extra.pop("format")
-        extra.update({"content_type": "application/json"})
+            format = extra.pop("format")
+        else:
+            format = None
+
+        if extra and "content_type" in extra:
+            content_type = extra.pop("content_type")
+        else:
+            content_type = None
+
+        # DRF wants either `format` or `content_type` but not both
+        if format and content_type:
+            extra.update({"content_type": "application/json"})
+        elif content_type:
+            extra.update({"content_type": "application/json"})
+        elif format:
+            extra.update({"format": "json"})
+        else:
+            extra.update({"content_type": "application/json"})
+
         kwargs["extra"] = extra
         return super().request(method, url_name, *args, **kwargs)
 

--- a/test_project/test_app/tests/test_unittests.py
+++ b/test_project/test_app/tests/test_unittests.py
@@ -636,8 +636,8 @@ class TestAPITestCaseDRFInstalled(APITestCase):
         self.post('view-json', data=data, extra={'format': 'json'})
         self.response_200()
 
-# pytest tests
 
+# pytest tests
 def test_tp_loads(tp):
     from django.test import Client
     assert isinstance(tp.client, Client)

--- a/test_project/test_app/tests/test_unittests.py
+++ b/test_project/test_app/tests/test_unittests.py
@@ -628,12 +628,26 @@ class TestAPITestCaseDRFInstalled(APITestCase):
 
     def test_post(self):
         data = {'testing': {'prop': 'value'}}
-        self.post('view-json', data=data)
+        response = self.post('view-json', data=data)
+        assert response["content-type"] == "application/json"
         self.response_200()
 
     def test_post_with_format(self):
         data = {'testing': {'prop': 'value'}}
-        self.post('view-json', data=data, extra={'format': 'json'})
+        response = self.post('view-json', data=data, extra={'format': 'json'})
+        assert response["content-type"] == "application/json"
+        self.response_200()
+
+    def test_post_with_content_type(self):
+        data = {'testing': {'prop': 'value'}}
+        response = self.post('view-json', data=data, extra={'content_type': 'application/json'})
+        assert response["content-type"] == "application/json"
+        self.response_200()
+
+    def test_post_with_format_and_content_type(self):
+        data = {'testing': {'prop': 'value'}}
+        response = self.post('view-json', data=data, extra={'format': 'json', 'content_type': 'application/json'})
+        assert response["content-type"] == "application/json"
         self.response_200()
 
 

--- a/test_project/test_app/tests/test_unittests.py
+++ b/test_project/test_app/tests/test_unittests.py
@@ -628,9 +628,13 @@ class TestAPITestCaseDRFInstalled(APITestCase):
 
     def test_post(self):
         data = {'testing': {'prop': 'value'}}
-        self.post('view-json', data=data, extra={'format': 'json'})
+        self.post('view-json', data=data)
         self.response_200()
 
+    def test_post_with_format(self):
+        data = {'testing': {'prop': 'value'}}
+        self.post('view-json', data=data, extra={'format': 'json'})
+        self.response_200()
 
 # pytest tests
 


### PR DESCRIPTION
Ok, I think this should handle the core part of #81. If I'm understanding the code correctly, the new `APITestCase.request()` method should be converting the `kwargs` data into JSON, and the `post/put/get/delete` methods are using that `request` method, so that should be doing what we want.

I'm not entirely clear on the `"HTTP_X_REQUESTED_WITH": "XMLHttpRequest"` bit, but it seems to be required for AJAXy stuff, at least according to [this](https://developer.mozilla.org/en-US/docs/Web/Guide/AJAX). But when I try to find it in the Django docs, the latest thing I see is something that was [deprecated in 3.1
](https://docs.djangoproject.com/en/4.1/releases/3.1/#id2)

I'm still looking into the `With an easy way to pass in headers like Authorization and Token stuff` part. I'm not great with crafting/modifying HTTP headers. But I think Burch did something like this on Uplight in a `just` command, so I'll look at that. I'm also looking at some of the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Messages#headers) on the topic.
