### PR TITLE
Revert `APITestCase` defaulting to JSON format.

### DIFF
--- a/test_plus/test.py
+++ b/test_plus/test.py
@@ -374,31 +374,6 @@ class APITestCase(TestCase):
         self.client_class = get_api_client()
         super(APITestCase, self).__init__(*args, **kwargs)
 
-    # APITest requests now default to JSON
-    def request(self, method, url_name, *args, **kwargs):
-        data = kwargs.pop("data", {})
-        extra = kwargs.pop("extra", {})
-        kwargs["data"] = json.dumps(data) if data is not None else None
-
-        if extra and "format" in extra:
-            format = extra.pop("format")
-        else:
-            format = None
-
-        if extra and "content_type" in extra:
-            content_type = extra.pop("content_type")
-        else:
-            content_type = None
-
-        # DRF wants either `format` or `content_type` but not both
-        if format and content_type is None:
-            extra.update({"format": "json"})
-        else:
-            extra.update({"content_type": "application/json"})
-
-        kwargs["extra"] = extra
-        return super().request(method, url_name, *args, **kwargs)
-
 
 # Note this class inherits from TestCase defined above.
 class CBVTestCase(TestCase):

--- a/test_project/test_app/tests/test_unittests.py
+++ b/test_project/test_app/tests/test_unittests.py
@@ -1,8 +1,8 @@
+import json
 import re
 import uuid
 
 import django
-import factory
 import factory.django
 import sys
 import unittest
@@ -641,13 +641,7 @@ class TestAPITestCaseDRFInstalled(APITestCase):
 
     def test_post_with_content_type(self):
         data = {'testing': {'prop': 'value'}}
-        response = self.post('view-json', data=data, extra={'content_type': 'application/json'})
-        assert response["content-type"] == "application/json"
-        self.response_200()
-
-    def test_post_with_format_and_content_type(self):
-        data = {'testing': {'prop': 'value'}}
-        response = self.post('view-json', data=data, extra={'format': 'json', 'content_type': 'application/json'})
+        response = self.post('view-json', data=json.dumps(data), extra={'content_type': 'application/json'})
         assert response["content-type"] == "application/json"
         self.response_200()
 

--- a/test_project/test_app/tests/test_unittests.py
+++ b/test_project/test_app/tests/test_unittests.py
@@ -650,6 +650,12 @@ class TestAPITestCaseDRFInstalled(APITestCase):
         assert response["content-type"] == "application/json"
         self.response_200()
 
+    def test_get_with_content_type(self):
+        data = {'testing': {'prop': 'value'}}
+        response = self.get('view-json', data=data, extra={'content_type': 'application/json'})
+        assert response["content-type"] == "application/json"
+        self.response_200()
+
 
 # pytest tests
 def test_tp_loads(tp):

--- a/test_project/test_app/tests/test_unittests.py
+++ b/test_project/test_app/tests/test_unittests.py
@@ -1,4 +1,5 @@
 import re
+import uuid
 
 import django
 import factory
@@ -650,9 +651,21 @@ class TestAPITestCaseDRFInstalled(APITestCase):
         assert response["content-type"] == "application/json"
         self.response_200()
 
+    def test_post_with_non_primitive_data_type(self):
+        data = {"uuid": uuid.uuid4()}
+        response = self.post('view-json', data=data)
+        assert response["content-type"] == "application/json"
+        self.response_200()
+
     def test_get_with_content_type(self):
         data = {'testing': {'prop': 'value'}}
         response = self.get('view-json', data=data, extra={'content_type': 'application/json'})
+        assert response["content-type"] == "application/json"
+        self.response_200()
+
+    def test_get_with_non_primitive_data_type(self):
+        data = {"uuid": uuid.uuid4()}
+        response = self.get('view-json', data=data)
         assert response["content-type"] == "application/json"
         self.response_200()
 

--- a/test_project/test_app/views.py
+++ b/test_project/test_app/views.py
@@ -83,8 +83,12 @@ def view_json(request):
     if not ctype.startswith('application/json'):
         raise ValueError("Request's content-type should be 'application/json'. Got '{}' instead.".format(ctype))
 
-    data = json.loads(request.body.decode('utf-8'))
-    return HttpResponse(json.dumps(data), content_type='application/json')
+    if request.method == 'POST':
+        data = json.loads(request.body.decode('utf-8'))
+        return HttpResponse(json.dumps(data), content_type='application/json')
+
+    return HttpResponse('', content_type='application/json')
+
 
 
 @login_required

--- a/test_project/test_app/views.py
+++ b/test_project/test_app/views.py
@@ -79,11 +79,10 @@ def view_redirect(request):
 
 
 def view_json(request):
-    ctype = request.META['CONTENT_TYPE']
-    if not ctype.startswith('application/json'):
-        raise ValueError("Request's content-type should be 'application/json'. Got '{}' instead.".format(ctype))
-
     if request.method == 'POST':
+        ctype = request.META['CONTENT_TYPE']
+        if not ctype.startswith('application/json'):
+            raise ValueError("Request's content-type should be 'application/json'. Got '{}' instead.".format(ctype))
         data = json.loads(request.body.decode('utf-8'))
         return HttpResponse(json.dumps(data), content_type='application/json')
 

--- a/test_project/test_project/settings.py
+++ b/test_project/test_project/settings.py
@@ -104,3 +104,7 @@ USE_TZ = True
 STATIC_URL = '/static/'
 
 TEST_RUNNER = 'test_plus.runner.NoLoggingRunner'
+
+REST_FRAMEWORK = {
+    'TEST_REQUEST_DEFAULT_FORMAT': 'json',
+}


### PR DESCRIPTION
It's an attempt to fix bug reported in #205 
It's been introduced in #190  

I've looked into it.
Changes i've introduced:
- added tests for GET requests
- corrected existing tests for POST requests (`format` and `content_type` options were used incorrectly)
- removed `APITestCase.request` as it's redundant. In #81 the solution should be to recommend users to set default format in tests. [DRF docs](https://www.django-rest-framework.org/api-guide/testing/#setting-the-default-format)

All changes are explained in commit messages.

All nox tests pass locally.