### PR TITLE
Use pytest's native python path support

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,5 +3,5 @@ DJANGO_SETTINGS_MODULE=test_project.settings
 addopts = --reuse-db
 norecursedirs = build dist docs .eggs/* *.egg-info htmlcov test_plus .git .tox
 python_files = test*.py
-site_dirs = test_project/
-testpaths = test_project
+pythonpath = test_project/
+test_paths = test_project

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,10 +52,9 @@ test =
 	factory-boy
 	flake8
 	pyflakes
-	pytest
+	pytest>=7.0
 	pytest-cov
 	pytest-django
-	pytest-pythonpath
 
 [aliases]
 test = pytest


### PR DESCRIPTION
This is added in Pytest 7

Fixes my failure to locally CI as mentioned in https://github.com/revsys/django-test-plus/pull/210#issuecomment-2081532869