### PR TITLE
Update how APITestCase's client is set for django>=5.2 compatibility

### DIFF
--- a/test_plus/test.py
+++ b/test_plus/test.py
@@ -375,9 +375,10 @@ class TestCase(DjangoTestCase, BaseTestCase):
 
 
 class APITestCase(TestCase):
-    def __init__(self, *args, **kwargs):
-        self.client_class = get_api_client()
-        super().__init__(*args, **kwargs)
+    def setUp(self):
+        super().setUp()
+        api_client_class = get_api_client()
+        self.client = api_client_class()
 
 
 # Note this class inherits from TestCase defined above.

--- a/test_project/test_app/tests/test_unittests.py
+++ b/test_project/test_app/tests/test_unittests.py
@@ -682,6 +682,10 @@ class TestAPITestCaseDRFInstalled(APITestCase):
         assert response["content-type"] == "application/json"
         self.response_200()
 
+    def test_force_authenticate(self):
+        u1 = self.make_user()
+        self.client.force_authenticate(u1)
+
 
 # pytest tests
 def test_tp_loads(tp):


### PR DESCRIPTION
This fixes https://github.com/revsys/django-test-plus/issues/215