### PR TITLE
Add `assertResponseMessages` method for Django 5.0+

### DIFF
--- a/docs/methods.rst
+++ b/docs/methods.rst
@@ -243,6 +243,43 @@ You can check that a specific template was not used to render the last response:
 
 This is a convenience wrapper around Django's ``assertTemplateNotUsed`` that automatically
 uses ``self.last_response`` if no response is provided.
+assertResponseMessages(expected_messages, response=None, ordered=True)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Available in Django 5.0+**
+
+Convenience wrapper for Django's ``MessagesTestMixin.assertMessages`` that uses ``self.last_response`` by default. For full details on the underlying assertion, see the `Django documentation on testing messages <https://docs.djangoproject.com/en/stable/ref/contrib/messages/#testing>`_.
+
+Example usage::
+
+    from django.contrib.messages import Message
+    from django.contrib.messages.constants import SUCCESS, ERROR
+
+    def test_success_message(self):
+        self.post('my-form-view', data={'name': 'Test'})
+        expected_messages = [
+            Message(level=SUCCESS, message='Form saved successfully!'),
+        ]
+        self.assertResponseMessages(expected_messages)
+
+    def test_multiple_messages(self):
+        self.post('my-form-view', data={'invalid': 'data'})
+        expected_messages = [
+            Message(level=ERROR, message='Name is required.'),
+            Message(level=ERROR, message='Email is required.'),
+        ]
+        self.assertResponseMessages(expected_messages)
+
+For Django versions before 5.0, this method will raise a ``NotImplementedError``. To skip tests conditionally::
+
+    import unittest
+    import django
+
+    @unittest.skipIf(django.VERSION < (5, 0), "assertResponseMessages requires Django 5.0+")
+    def test_messages(self):
+        self.get('view-with-messages')
+        expected_messages = [Message(level=SUCCESS, message='Done!')]
+        self.assertResponseMessages(expected_messages)
 
 get\_check\_200(url\_name, \*args, \*\*kwargs)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/test_plus/compat.py
+++ b/test_plus/compat.py
@@ -35,8 +35,10 @@ else:
 
 try:
     from django.contrib.messages.test import MessagesTestMixin
+
     assertMessages = MessagesTestMixin.assertMessages
 except ImportError:
+
     def assertMessages(t, response, expected_messages, ordered=True):
         raise NotImplementedError(
             "Your version of Django does not support `assertMessages`. "

--- a/test_plus/compat.py
+++ b/test_plus/compat.py
@@ -31,3 +31,14 @@ else:
 
     def assertURLEqual(t, url1, url2, msg_prefix=""):
         raise NotImplementedError("Your version of Django does not support `assertURLEqual`")
+
+
+try:
+    from django.contrib.messages.test import MessagesTestMixin
+    assertMessages = MessagesTestMixin.assertMessages
+except ImportError:
+    def assertMessages(t, response, expected_messages, ordered=True):
+        raise NotImplementedError(
+            "Your version of Django does not support `assertMessages`. "
+            "This method is only available in Django 5.0 and later."
+        )

--- a/test_plus/test.py
+++ b/test_plus/test.py
@@ -20,7 +20,7 @@ from django.test.utils import CaptureQueriesContext
 
 from test_plus.status_codes import StatusCodeAssertionMixin
 
-from .compat import NoReverseMatch, assertURLEqual, get_api_client, reverse
+from .compat import NoReverseMatch, assertMessages, assertURLEqual, get_api_client, reverse
 
 
 class NoPreviousResponse(Exception):
@@ -370,6 +370,19 @@ class BaseTestCase(StatusCodeAssertionMixin):
 
     def assertContext(self, key, value):
         self.assertEqual(self.get_context(key), value)
+
+    def assertResponseMessages(self, expected_messages, response=None, ordered=True):
+        """
+        Convenience wrapper for assertMessages that uses the last response by default.
+
+        Tests that the messages in the response match the expected messages.
+
+        :param expected_messages: List of Message objects to compare against
+        :param response: Response to check messages against (defaults to last_response)
+        :param ordered: If True, messages must match in order (default: True)
+        """
+        response = self._which_response(response)
+        assertMessages(self, response, expected_messages, ordered=ordered)
 
 
 class TestCase(DjangoTestCase, BaseTestCase):

--- a/test_project/test_app/tests/test_unittests.py
+++ b/test_project/test_app/tests/test_unittests.py
@@ -9,9 +9,15 @@ import django
 import factory.django
 import pytest
 from django.contrib.auth import get_user_model
-from django.contrib.messages import Message
-from django.contrib.messages.constants import INFO, SUCCESS, WARNING
 from django.core.exceptions import ImproperlyConfigured
+
+try:
+    from django.contrib.messages import Message
+    from django.contrib.messages.constants import INFO, SUCCESS, WARNING
+except ImportError:
+    # Message class not available in Django < 5.0
+    Message = None
+    SUCCESS = INFO = WARNING = None
 
 try:
     from StringIO import StringIO
@@ -507,28 +513,28 @@ class TestPlusViewTests(TestCase):
     def test_assert_response_messages(self):
         """Test assertResponseMessages with Django 5.0+ messages framework using last_response"""
         expected_messages = [
-            Message(level=SUCCESS, message='Success message'),
-            Message(level=INFO, message='Info message'),
-            Message(level=WARNING, message='Warning message'),
+            Message(level=SUCCESS, message="Success message"),
+            Message(level=INFO, message="Info message"),
+            Message(level=WARNING, message="Warning message"),
         ]
-        self.get('view-with-messages')
+        self.get("view-with-messages")
         self.assertResponseMessages(expected_messages)
 
     @unittest.skipIf(django.VERSION < (5, 0), "assertResponseMessages is only available in Django 5.0+")
     def test_assert_response_messages_with_explicit_response(self):
         """Test assertResponseMessages with explicit response parameter"""
         expected_messages = [
-            Message(level=SUCCESS, message='Success message'),
-            Message(level=INFO, message='Info message'),
-            Message(level=WARNING, message='Warning message'),
+            Message(level=SUCCESS, message="Success message"),
+            Message(level=INFO, message="Info message"),
+            Message(level=WARNING, message="Warning message"),
         ]
-        response = self.get('view-with-messages')
+        response = self.get("view-with-messages")
         self.assertResponseMessages(expected_messages, response=response)
 
     @unittest.skipUnless(django.VERSION < (5, 0), "Test for Django versions before 5.0")
     def test_assert_response_messages_not_available(self):
         """Test that assertResponseMessages raises NotImplementedError on Django < 5.0"""
-        self.get('view-200')
+        self.get("view-200")
 
         with self.assertRaisesRegex(NotImplementedError, r"does not support `assertMessages`.*Django 5\.0"):
             self.assertResponseMessages([])

--- a/test_project/test_app/tests/test_unittests.py
+++ b/test_project/test_app/tests/test_unittests.py
@@ -9,6 +9,8 @@ import django
 import factory.django
 import pytest
 from django.contrib.auth import get_user_model
+from django.contrib.messages import Message
+from django.contrib.messages.constants import INFO, SUCCESS, WARNING
 from django.core.exceptions import ImproperlyConfigured
 
 try:
@@ -500,6 +502,36 @@ class TestPlusViewTests(TestCase):
         self.assertResponseHeaders({"X-Custom": "1"})
         self.assertResponseHeaders({"X-Custom": "1", "X-Non-Existent": None})
         self.assertResponseHeaders({"X-Non-Existent": None})
+
+    @unittest.skipIf(django.VERSION < (5, 0), "assertResponseMessages is only available in Django 5.0+")
+    def test_assert_response_messages(self):
+        """Test assertResponseMessages with Django 5.0+ messages framework using last_response"""
+        expected_messages = [
+            Message(level=SUCCESS, message='Success message'),
+            Message(level=INFO, message='Info message'),
+            Message(level=WARNING, message='Warning message'),
+        ]
+        self.get('view-with-messages')
+        self.assertResponseMessages(expected_messages)
+
+    @unittest.skipIf(django.VERSION < (5, 0), "assertResponseMessages is only available in Django 5.0+")
+    def test_assert_response_messages_with_explicit_response(self):
+        """Test assertResponseMessages with explicit response parameter"""
+        expected_messages = [
+            Message(level=SUCCESS, message='Success message'),
+            Message(level=INFO, message='Info message'),
+            Message(level=WARNING, message='Warning message'),
+        ]
+        response = self.get('view-with-messages')
+        self.assertResponseMessages(expected_messages, response=response)
+
+    @unittest.skipUnless(django.VERSION < (5, 0), "Test for Django versions before 5.0")
+    def test_assert_response_messages_not_available(self):
+        """Test that assertResponseMessages raises NotImplementedError on Django < 5.0"""
+        self.get('view-200')
+
+        with self.assertRaisesRegex(NotImplementedError, r"does not support `assertMessages`.*Django 5\.0"):
+            self.assertResponseMessages([])
 
 
 class TestPlusCBViewTests(CBVTestCase):

--- a/test_project/test_app/urls.py
+++ b/test_project/test_app/urls.py
@@ -34,6 +34,7 @@ from .views import (
     view_is_ajax,
     view_json,
     view_redirect,
+    view_with_messages,
 )
 
 urlpatterns = [
@@ -62,6 +63,7 @@ urlpatterns = [
     url(r"^view/contains/$", view_contains, name="view-contains"),
     url(r"^view/form-errors/$", FormErrors.as_view(), name="form-errors"),
     url(r"^view/headers/$", view_headers, name="view-headers"),
+    url(r"^view/with-messages/$", view_with_messages, name="view-with-messages"),
     url(r"^cbview/needs-login/$", CBLoginRequiredView.as_view(), name="cbview-needs-login"),
     url(r"^cbview/$", CBView.as_view(), name="cbview"),
 ]

--- a/test_project/test_app/views.py
+++ b/test_project/test_app/views.py
@@ -1,5 +1,6 @@
 import json
 
+from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse, HttpResponseGone
 from django.shortcuts import redirect, render
@@ -185,3 +186,10 @@ class CBTemplateView(generic.TemplateView):
 class FormErrors(generic.FormView):
     form_class = NameForm
     template_name = "form_errors.html"
+
+
+def view_with_messages(request):
+    messages.success(request, "Success message")
+    messages.info(request, "Info message")
+    messages.warning(request, "Warning message")
+    return render(request, "base.html", {})


### PR DESCRIPTION
Added convenience wrapper for Django's `MessagesTestMixin.assertMessages`:

- Uses `self.last_response` by default following library conventions
- Clean compatibility wrapper in `compat.py` with single try/except
- Comprehensive tests with proper `Message` construction
- Documentation with examples and Django version skip pattern
- Test view and URL for demonstration

Ref: https://docs.djangoproject.com/en/5.0/ref/contrib/messages/#testing
