### PR TITLE
Add Django 6.0 and Python 3.14 support

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -68,12 +68,12 @@ jobs:
       - name: Install Django ${{ matrix.django-version }}
         if: ${{ matrix.drf-version == '' }}
         run: |
-          python -m uv pip install --system --prerelease=if-necessary-or-explicit "Django~=${{ matrix.django-version }}.0"
+          python -m uv pip install --system --prerelease=if-necessary-or-explicit "Django>=${{ matrix.django-version }}a1,<${{ matrix.django-version | int + 1 }}"
 
       - name: Install DRF ${{ matrix.drf-version }} and Django ${{ matrix.django-version }}
         if: ${{ matrix.drf-version }}
         run: |
-          python -m uv pip install --system --prerelease=if-necessary-or-explicit pytz "djangorestframework~=${{ matrix.drf-version }}.0" "Django~=${{ matrix.django-version }}.0"
+          python -m uv pip install --system --prerelease=if-necessary-or-explicit pytz "djangorestframework~=${{ matrix.drf-version }}.0" "Django>=${{ matrix.django-version }}a1,<${{ matrix.django-version | int + 1 }}"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -68,12 +68,12 @@ jobs:
       - name: Install Django ${{ matrix.django-version }}
         if: ${{ matrix.drf-version == '' }}
         run: |
-          python -m uv pip install --system "Django~=${{ matrix.django-version }}.0"
+          python -m uv pip install --system --prerelease=if-necessary-or-explicit "Django~=${{ matrix.django-version }}.0"
 
       - name: Install DRF ${{ matrix.drf-version }} and Django ${{ matrix.django-version }}
         if: ${{ matrix.drf-version }}
         run: |
-          python -m uv pip install --system pytz "djangorestframework~=${{ matrix.drf-version }}.0" "Django~=${{ matrix.django-version }}.0"
+          python -m uv pip install --system --prerelease=if-necessary-or-explicit pytz "djangorestframework~=${{ matrix.drf-version }}.0" "Django~=${{ matrix.django-version }}.0"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -23,10 +23,13 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
+          - "3.14"
         django-version:
           - "4.2"  # LTS
           - "5.1"
           - "5.2"  # LTS
+          - "6.0"
         drf-version:
           - ""
           # - "3.12"
@@ -41,6 +44,12 @@ jobs:
             django-version: "5.1"
           - python-version: "3.9"
             django-version: "5.2"
+          - python-version: "3.9"
+            django-version: "6.0"
+
+          # Django 6.0 is compatible with Python 3.11+
+          - python-version: "3.10"
+            django-version: "6.0"
           
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -66,14 +66,24 @@ jobs:
           python -m pip install uv
 
       - name: Install Django ${{ matrix.django-version }}
-        if: ${{ matrix.drf-version == '' }}
+        if: ${{ matrix.drf-version == '' && matrix.django-version != '6.0' }}
         run: |
-          python -m uv pip install --system --prerelease=if-necessary-or-explicit "Django>=${{ matrix.django-version }}a1,<${{ matrix.django-version | int + 1 }}"
+          python -m uv pip install --system "Django~=${{ matrix.django-version }}.0"
+
+      - name: Install Django ${{ matrix.django-version }} (pre-release)
+        if: ${{ matrix.drf-version == '' && matrix.django-version == '6.0' }}
+        run: |
+          python -m uv pip install --system --prerelease=if-necessary-or-explicit "Django>=6.0a1,<6.1"
 
       - name: Install DRF ${{ matrix.drf-version }} and Django ${{ matrix.django-version }}
-        if: ${{ matrix.drf-version }}
+        if: ${{ matrix.drf-version && matrix.django-version != '6.0' }}
         run: |
-          python -m uv pip install --system --prerelease=if-necessary-or-explicit pytz "djangorestframework~=${{ matrix.drf-version }}.0" "Django>=${{ matrix.django-version }}a1,<${{ matrix.django-version | int + 1 }}"
+          python -m uv pip install --system pytz "djangorestframework~=${{ matrix.drf-version }}.0" "Django~=${{ matrix.django-version }}.0"
+
+      - name: Install DRF ${{ matrix.drf-version }} and Django ${{ matrix.django-version }} (pre-release)
+        if: ${{ matrix.drf-version && matrix.django-version == '6.0' }}
+        run: |
+          python -m uv pip install --system --prerelease=if-necessary-or-explicit pytz "djangorestframework~=${{ matrix.drf-version }}.0" "Django>=6.0a1,<6.1"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -47,9 +47,17 @@ jobs:
           - python-version: "3.9"
             django-version: "6.0"
 
-          # Django 6.0 is compatible with Python 3.11+
+          # Django 6.0 is compatible with Python 3.12+
           - python-version: "3.10"
             django-version: "6.0"
+          - python-version: "3.11"
+            django-version: "6.0"
+
+          # Python 3.14 is compatible with Django 5.2+
+          - python-version: "3.14"
+            django-version: "4.2"
+          - python-version: "3.14"
+            django-version: "5.1"
           
     steps:
       - uses: actions/checkout@v4

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifiers =
 	Framework :: Django :: 4.2
 	Framework :: Django :: 5.1
 	Framework :: Django :: 5.2
+	Framework :: Django :: 6.0
 	Framework :: Pytest
 	Intended Audience :: Developers
 	License :: OSI Approved :: BSD License
@@ -29,6 +30,7 @@ classifiers =
 	Programming Language :: Python :: 3.11
 	Programming Language :: Python :: 3.12
 	Programming Language :: Python :: 3.13
+	Programming Language :: Python :: 3.14
 
 [options]
 include_package_data = True
@@ -39,7 +41,7 @@ setup_requires =
 	pytest-runner
 	pytest-django
 tests_require = django-test-plus[test]
-python_requires = >=3.9, <3.14
+python_requires = >=3.9, <3.15
 
 [options.entry_points]
 pytest11 = 


### PR DESCRIPTION
## Summary

Adds support for Django 6.0 (currently alpha) and Python 3.14 to the testing matrix and classifiers.

### Changes to `.github/workflows/actions.yml`
- Added Python 3.13 and 3.14 to CI testing matrix
- Added Django 6.0 to CI testing matrix
- Added exclusions for incompatible Python/Django version combinations:
  - Django 6.0 requires Python 3.12+ (excludes Python 3.9, 3.10, 3.11)
  - Python 3.14 requires Django 5.2+ (excludes Django 4.2, 5.1)
  - Django 5.1+ requires Python 3.10+ (excludes Python 3.9)
- Split Django installation into separate steps for stable vs pre-release versions:
  - Stable versions (4.2, 5.1, 5.2): use `Django~=X.Y.0` without prerelease flag
  - Django 6.0 (alpha): use `Django>=6.0a1,<6.1` with `--prerelease=if-necessary-or-explicit` flag
- This ensures proper minor version handling and explicit alpha support

### Changes to `setup.cfg`
- Updated Python classifiers to include Python 3.14
- Updated Django classifiers to include Django 6.0
- Updated `python_requires` constraint from `>=3.9, <3.14` to `>=3.9, <3.15`

This enables early testing against Django 6.0 alpha to provide feedback to Django developers before the stable release.

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)