### PR TITLE
Add `assertResponseTemplateUsed` and `assertResponseTemplateNotUsed` methods

### DIFF
--- a/docs/methods.rst
+++ b/docs/methods.rst
@@ -220,6 +220,30 @@ You might also want to check standard headers::
         self.get('my-json-view')
         self.assertResponseHeaders({'Content-Type': 'application/json'})
 
+assertResponseTemplateUsed(template\_name, response=None)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can check that a specific template was used to render the last response::
+
+    def test_template_used(self):
+        self.get('my-view')
+        self.assertResponseTemplateUsed('my_template.html')
+
+This is a convenience wrapper around Django's ``assertTemplateUsed`` that automatically
+uses ``self.last_response`` if no response is provided.
+
+assertResponseTemplateNotUsed(template\_name, response=None)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can check that a specific template was not used to render the last response::
+
+    def test_template_not_used(self):
+        self.get('my-view')
+        self.assertResponseTemplateNotUsed('other_template.html')
+
+This is a convenience wrapper around Django's ``assertTemplateNotUsed`` that automatically
+uses ``self.last_response`` if no response is provided.
+
 get\_check\_200(url\_name, \*args, \*\*kwargs)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/test_plus/test.py
+++ b/test_plus/test.py
@@ -332,6 +332,16 @@ class BaseTestCase(StatusCodeAssertionMixin):
         response = self._which_response(response)
         self.assertNotContains(response, text, html=html, **kwargs)
 
+    def assertResponseTemplateUsed(self, template_name, response=None, **kwargs):
+        """Convenience wrapper for assertTemplateUsed"""
+        response = self._which_response(response)
+        self.assertTemplateUsed(response, template_name, **kwargs)
+
+    def assertResponseTemplateNotUsed(self, template_name, response=None, **kwargs):
+        """Convenience wrapper for assertTemplateNotUsed"""
+        response = self._which_response(response)
+        self.assertTemplateNotUsed(response, template_name, **kwargs)
+
     def assertResponseHeaders(self, headers, response=None):
         """
         Check that the headers in the response are as expected.

--- a/test_project/test_app/tests/test_unittests.py
+++ b/test_project/test_app/tests/test_unittests.py
@@ -486,6 +486,14 @@ class TestPlusViewTests(TestCase):
         self.assertResponseContains("<p>Hello world</p>")
         self.assertResponseNotContains("<p>Hello Frank</p>")
 
+    def test_assertresponsetemplateused(self):
+        self.get("view-contains")
+        self.assertResponseTemplateUsed("test.html")
+
+    def test_assertresponsetemplatenotused(self):
+        self.get("view-contains")
+        self.assertResponseTemplateNotUsed("other.html")
+
     def test_assert_response_headers(self):
         self.get("view-headers")
         self.assertResponseHeaders({"Content-Type": "text/plain"})


### PR DESCRIPTION
- Add `assertResponseTemplateUsed()` convenience wrapper for `assertTemplateUsed`
- Add `assertResponseTemplateNotUsed()` convenience wrapper for `assertTemplateNotUsed`
- Add tests for both new assertion methods
- Add documentation for new methods in `docs/methods.rst`
