### PR TITLE
:wrench: Add Django 6.1 to test matrix + free-threading classifier

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -30,6 +30,7 @@ jobs:
           - "5.1"
           - "5.2"  # LTS
           - "6.0"
+          - "6.1"
         drf-version:
           - ""
           # - "3.12"
@@ -43,6 +44,11 @@ jobs:
             django-version: "6.0"
           - python-version: "3.11"
             django-version: "6.0"
+          # Django 6.1 is compatible with Python 3.12+
+          - python-version: "3.10"
+            django-version: "6.1"
+          - python-version: "3.11"
+            django-version: "6.1"
           # Django 4.2 is not compatible with Python 3.14+
           - python-version: "3.14"
             django-version: "4.2"
@@ -68,15 +74,26 @@ jobs:
         run: |
           python -m pip install uv
 
+      - name: Resolve Django ${{ matrix.django-version }} specifier
+        run: |
+          # Django versions without a final release need a specifier that opts
+          # in to pre-releases. Naming the pre-release also lets the same spec
+          # pick up the final release once it ships, so these cases can just be
+          # dropped then.
+          case "${{ matrix.django-version }}" in
+            6.1) echo 'DJANGO_SPEC=Django>=6.1rc1,<6.2' >> "$GITHUB_ENV" ;;
+            *)   echo 'DJANGO_SPEC=Django~=${{ matrix.django-version }}.0' >> "$GITHUB_ENV" ;;
+          esac
+
       - name: Install Django ${{ matrix.django-version }}
         if: ${{ matrix.drf-version == '' }}
         run: |
-          python -m uv pip install --system "Django~=${{ matrix.django-version }}.0"
+          python -m uv pip install --system "$DJANGO_SPEC"
 
       - name: Install DRF ${{ matrix.drf-version }} and Django ${{ matrix.django-version }}
         if: ${{ matrix.drf-version }}
         run: |
-          python -m uv pip install --system pytz "djangorestframework~=${{ matrix.drf-version }}.0" "Django~=${{ matrix.django-version }}.0"
+          python -m uv pip install --system pytz "djangorestframework~=${{ matrix.drf-version }}.0" "$DJANGO_SPEC"
 
       - name: Install dependencies
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## Unreleased
+
+  - Add Django 6.1 support
+  - Advertise support for the Python 3.14 free-threaded build (3.14t), which
+    was already covered by the test matrix
+
 ## Version 2.4.1 - December 19th, 2025
 
   - Migrate from setup.py/setup.cfg to pyproject.toml with hatchling

--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ to help your team dramatically improve your productivity.
 
 ## Support
 
-- Python 3.10, 3.11, 3.12, 3.13, and 3.14.
+- Python 3.10, 3.11, 3.12, 3.13, and 3.14, including the 3.14 free-threaded
+  build (3.14t).
 
-- Django 4.2 LTS, 5.1, 5.2 LTS, and 6.0.
+- Django 4.2 LTS, 5.1, 5.2 LTS, 6.0, and 6.1.
 
 ## Documentation
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,12 +1,21 @@
 import nox
 
-DJANGO_VERSIONS = ["4.2", "5.1", "5.2", "6.0"]
+DJANGO_VERSIONS = ["4.2", "5.1", "5.2", "6.0", "6.1"]
 DRF_VERSIONS = ["3.15", "3.16"]
 PYTHON_VERSIONS = ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
+
+# Django versions that have no final release yet need a specifier that opts in
+# to pre-releases. Naming the pre-release also lets the same spec pick up the
+# final release once it ships, so these entries can just be deleted then.
+DJANGO_SPECS = {
+    "6.1": "django>=6.1rc1,<6.2",
+}
 
 INVALID_PYTHON_DJANGO_SESSIONS = [
     ("3.10", "6.0"),
     ("3.11", "6.0"),
+    ("3.10", "6.1"),
+    ("3.11", "6.1"),
     ("3.14", "4.2"),
     ("3.14", "5.1"),
     ("3.14t", "4.2"),
@@ -25,7 +34,7 @@ def tests(session: nox.Session, django: str) -> None:
     if (session.python, django) in INVALID_PYTHON_DJANGO_SESSIONS:
         session.skip()
     session.install(".[test]")
-    session.install(f"django~={django}")
+    session.install(DJANGO_SPECS.get(django, f"django~={django}"))
     session.run("pytest", *session.posargs)
 
 
@@ -46,6 +55,6 @@ def tests_drf(session: nox.Session, django: str, drf: str) -> None:
     if (drf, session.python) in INVALID_DRF_PYTHON_SESSIONS:
         session.skip()
     session.install(".[test]")
-    session.install(f"django~={django}")
+    session.install(DJANGO_SPECS.get(django, f"django~={django}"))
     session.install(f"djangorestframework~={drf}")
     session.run("pytest", *session.posargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
     "Framework :: Django :: 6.0",
+    "Framework :: Django :: 6.1",
     "Framework :: Pytest",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
@@ -29,6 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: Free Threading :: 3 - Stable",
 ]
 dependencies = ["packaging"]
 requires-python = ">=3.10"


### PR DESCRIPTION
Adds Django 6.1 to the test matrix and advertises free-threaded Python support.

## Django 6.1

**Heads up: 6.1 has no final release yet.** PyPI currently has `6.1a1`, `6.1b1`, and `6.1rc1` — latest stable is 6.0.7. So `Django~=6.1.0` resolves to nothing, and the matrix needed a pre-release-aware specifier.

The spec used is `django>=6.1rc1,<6.2`. Because it names a pre-release, PEP 440 makes pre-releases eligible for that specifier without any global `--prerelease` flag, and the same spec will pick up 6.1 final once it ships. The special-casing is isolated in one place each:

- `noxfile.py` — a `DJANGO_SPECS` override dict
- `.github/workflows/actions.yml` — a `Resolve Django specifier` step that sets `DJANGO_SPEC` in the env

Both are commented so the entry can simply be deleted once 6.1 is out, with no other changes needed.

Django 6.1 requires Python 3.12+, so 3.10 and 3.11 are excluded in both the nox skip list and the Actions matrix, matching how 6.0 is handled.

Also adds the `Framework :: Django :: 6.1` trove classifier (confirmed valid against `trove-classifiers`).

## Free-threading

Python **3.14t was already in both matrices and already passing** — that coverage predates this PR. So there was nothing to add on the testing side; this only makes the existing support visible:

- `Programming Language :: Python :: Free Threading :: 3 - Stable` trove classifier
- README mention

On the classifier level: this is pure Python with no C extensions and no shared mutable module state, and the suite passes clean on 3.14t, so `3 - Stable` seems right. Happy to drop to `2 - Beta` if you'd rather be conservative on the first release that claims it.

## README + changelog

Refreshed the Support section:

- Python line now notes the 3.14 free-threaded build (3.14t)
- Django line now reads `4.2 LTS, 5.1, 5.2 LTS, 6.0, and 6.1`

Added an Unreleased changelog entry.

## Verification

Locally against `6.1rc1` — 84 passed, 2 xfailed on each of Python 3.12, 3.13, 3.14, and 3.14t. Confirmed the nox session resolves to `django 6.1rc1` and that 3.10/3.11 correctly skip. `prek run --all-files` is clean.
