### PR TITLE
:wrench: Fix broken justfile targets and add missing nox sessions

### DIFF
--- a/justfile
+++ b/justfile
@@ -22,11 +22,11 @@
 
 # Run test coverage report
 @coverage *ARGS="--no-install --reuse-existing-virtualenvs":
-    python -m nox {{ ARGS }} --session "coverage"
+    uv tool run nox {{ ARGS }} --session "coverage"
 
 # Build documentation
 @docs *ARGS="--no-install --reuse-existing-virtualenvs":
-    python -m nox {{ ARGS }} --session "docs"
+    uv tool run nox {{ ARGS }} --session "docs"
 
 # Format justfile
 @fmt:
@@ -34,15 +34,15 @@
 
 # Run linting checks
 @lint *ARGS="--no-install --reuse-existing-virtualenvs":
-    python -m nox {{ ARGS }} --session "lint"
+    uv tool run nox {{ ARGS }} --session "lint"
 
-# Compile requirements lock file
-@lock:
-    python -m piptools compile --resolver=backtracking
+# Compile the uv lock file
+@lock *ARGS:
+    uv lock {{ ARGS }}
 
 # Run all nox sessions
 @nox *ARGS="--no-install --reuse-existing-virtualenvs":
-    python -m nox {{ ARGS }}
+    uv tool run nox {{ ARGS }}
 
 # Build and publish a release to PyPI
 @release:
@@ -53,16 +53,16 @@
 
 # Run all tests
 @test *ARGS="--no-install --reuse-existing-virtualenvs":
-    python -m nox {{ ARGS }}
+    uv tool run nox {{ ARGS }}
 
 # Run tests with Django REST Framework
 @test-drf *ARGS="--no-install --reuse-existing-virtualenvs":
-    python -m nox {{ ARGS }} --session "tests_drf"
+    uv tool run nox {{ ARGS }} --session "tests_drf"
 
 # Run tests in current environment
 @test-env *ARGS="--no-install --reuse-existing-virtualenvs":
-    python -m nox {{ ARGS }} --session "tests_env"
+    uv tool run nox {{ ARGS }} --session "tests_env"
 
 # Run tests with latest Python and Django versions
 @test-latest *ARGS="--no-install --reuse-existing-virtualenvs":
-    python -m nox {{ ARGS }} --session "tests-3.12(django='5.1')"
+    uv tool run nox {{ ARGS }} --session "tests-3.14(django='6.1')"

--- a/noxfile.py
+++ b/noxfile.py
@@ -44,6 +44,26 @@ def lint(session: nox.Session) -> None:
     session.run("prek", "run", "--all-files", *session.posargs)
 
 
+@nox.session(venv_backend="uv")
+def docs(session: nox.Session) -> None:
+    session.install(".[docs]")
+    session.run("sphinx-build", "-b", "html", "docs", "docs/_build/html", *session.posargs)
+
+
+@nox.session(venv_backend="uv")
+def coverage(session: nox.Session) -> None:
+    # Editable, so coverage measures ./test_plus rather than a copy in
+    # site-packages that it would never see reported.
+    session.install("-e", ".[test]", "django", "djangorestframework")
+    session.run("pytest", "--cov", "--cov-report=term-missing", *session.posargs)
+
+
+@nox.session(venv_backend="none")
+def tests_env(session: nox.Session) -> None:
+    """Run the tests in the active environment, without building a virtualenv."""
+    session.run("pytest", *session.posargs)
+
+
 @nox.session(python=PYTHON_VERSIONS, tags=["drf"], venv_backend="uv")
 @nox.parametrize("django", DJANGO_VERSIONS)
 @nox.parametrize("drf", DRF_VERSIONS)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,8 @@ Homepage = "https://github.com/revsys/django-test-plus/"
 pytest11 = { test_plus = "test_plus.plugin" }
 
 [project.optional-dependencies]
-docs = ["sphinx", "furo", "sphinx-copybutton", "sphinx-prompt"]
+# docs/conf.py calls django.setup(), so Django is needed to build the docs.
+docs = ["django", "sphinx", "furo", "sphinx-copybutton", "sphinx-prompt"]
 lint = ["prek"]
 test = ["factory-boy", "pytest", "pytest-cov", "pytest-django"]
 testing = ["django-test-plus[test]"]


### PR DESCRIPTION
`just docs` invoked a nox session named `docs` that was never defined, so it failed outright. Chasing that turned up the same bug in two more targets and a few adjacent problems.

## The missing sessions

The justfile referenced `docs`, `coverage`, and `tests_env`, but `noxfile.py` only defined `tests`, `tests_drf`, and `lint`. (`lint` had the identical bug until it was fixed in #227.) This adds the three missing sessions.

## Two latent bugs found while verifying them

**The `docs` extra could not build the docs.** `docs/conf.py` calls `django.setup()`, but the extra was `["sphinx", "furo", "sphinx-copybutton", "sphinx-prompt"]` — no Django. So even a correct `docs` session would have died on `ModuleNotFoundError: No module named 'django'`. Django is now in the extra.

**The coverage session would have reported nothing, silently.** Installing the package non-editable means tests import `test_plus` from site-packages while coverage watches `./test_plus`, so it emitted `CovReportWarning: Failed to generate report: No data to report.` and still exited 0. Installing editable fixes it. DRF is also installed now, so the 8 DRF tests run instead of skipping.

Before: `76 passed, 8 skipped` and no coverage data.
After: `84 passed`, `TOTAL 423 stmts, 167 miss, 61%`.

## Other stale targets

- **`just lock`** ran `piptools compile --resolver=backtracking` against a requirements file this project no longer has — it moved to `uv.lock`. Now runs `uv lock`.
- **`just test-latest`** was pinned to `tests-3.12(django='5.1')`, which stopped being "latest" some time ago. Now `tests-3.14(django='6.1')`.
- **nox is now invoked via `uv tool run`**, matching how the justfile already calls bumpver. Previously every nox-backed target assumed `python -m nox` resolved, which fails on a machine that hasn't run `just bootstrap` — that's what I hit locally.

## Verified

`just docs` (build succeeded), `just coverage` (84 passed, real report), and `just lint` (all hooks pass) all run clean. `prek run --all-files` is clean. Build output is already gitignored (`.nox/`, `docs/_build/`, `htmlcov/`).

## One thing I did not change

`[tool.coverage.report] fail_under = 75`, but actual coverage is **61%**, and nothing currently enforces the threshold — the session exits 0 regardless. AGENTS.md also advertises "75% minimum". Someone should decide whether to enforce the gate (which would fail today), lower it to match reality, or drop it. Left alone here since it's a policy call, not a bug fix.
