### PR TITLE
Accept plain URLs and a method= in assertLoginRequired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+  - `assertLoginRequired()` now accepts a plain URL, matching what `get()` and
+    the other request helpers accept
+  - Add a `method` argument to `assertLoginRequired()` for testing views that
+    require login on verbs other than GET
+  - Resolve URLs outside the `NoReverseMatch` handler in `request()`, so a
+    failing request no longer reports an unrelated `reverse()` traceback and a
+    `NoReverseMatch` raised by the view itself is no longer swallowed
   - Add Django 6.1 support
   - Advertise support for the Python 3.14 free-threaded build (3.14t), which
     was already covered by the test matrix

--- a/docs/auth_helpers.rst
+++ b/docs/auth_helpers.rst
@@ -1,7 +1,7 @@
 Authentication Helpers
 ----------------------
 
-assertLoginRequired(url\_name, \*args, \*\*kwargs)
+assertLoginRequired(url\_name, \*args, method='get', \*\*kwargs)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This method helps you test that a given named URL requires authorization::
@@ -10,6 +10,21 @@ This method helps you test that a given named URL requires authorization::
         self.assertLoginRequired('my-restricted-url')
         self.assertLoginRequired('my-restricted-object', pk=12)
         self.assertLoginRequired('my-restricted-object', slug='something')
+
+Like ``self.get()`` and friends, a plain URL works too when the name cannot be
+reversed::
+
+    def test_auth_by_url(self):
+        self.assertLoginRequired('/restricted/')
+
+Pass ``method`` to check a verb other than GET, which is useful for views that
+only accept writes::
+
+    def test_auth_on_post(self):
+        self.assertLoginRequired('my-restricted-url', method='post')
+
+``method`` accepts any verb supported by ``request()``: ``get``, ``post``,
+``put``, ``patch``, ``head``, ``trace``, ``options``, and ``delete``.
 
 login context
 ~~~~~~~~~~~~~

--- a/test_plus/test.py
+++ b/test_plus/test.py
@@ -241,12 +241,16 @@ class BaseTestCase(StatusCodeAssertionMixin):
         self.response_200(response)
         return response
 
-    def assertLoginRequired(self, url, *args, **kwargs):
-        """Ensure login is required to GET this URL"""
-        response = self.get(url, *args, **kwargs)
-        reversed_url = reverse(url, args=args, kwargs=kwargs)
+    def assertLoginRequired(self, url, *args, method="get", **kwargs):
+        """
+        Ensure login is required to access this URL via <method> (default GET)
+
+        `url` may be a url name or a plain URL, matching what request() accepts.
+        """
+        response = self.request(method, url, *args, **kwargs)
+        resolved_url = self._resolve_url(url, *args, **kwargs)
         login_url = str(resolve_url(settings.LOGIN_URL))
-        expected_url = f"{login_url}?next={reversed_url}"
+        expected_url = f"{login_url}?next={resolved_url}"
         self.assertRedirects(response, expected_url)
 
     assertRedirects = DjangoTestCase.assertRedirects
@@ -529,13 +533,9 @@ class CBVTestCase(TestCase):
         self.response_200(response)
         return response
 
-    def assertLoginRequired(self, url, *args, **kwargs):
-        """Ensure login is required to GET this URL"""
-        response = super().get(url, *args, **kwargs)
-        reversed_url = reverse(url, args=args, kwargs=kwargs)
-        login_url = str(resolve_url(settings.LOGIN_URL))
-        expected_url = f"{login_url}?next={reversed_url}"
-        self.assertRedirects(response, expected_url)
+    # assertLoginRequired is inherited from BaseTestCase. It goes through
+    # request() rather than get(), so it is unaffected by this class
+    # overriding get() to take a view class.
 
     def assertGoodView(self, url_name, *args, **kwargs):
         """

--- a/test_project/test_app/tests/test_unittests.py
+++ b/test_project/test_app/tests/test_unittests.py
@@ -420,6 +420,18 @@ class TestPlusViewTests(TestCase):
         with self.login(user):
             self.get_check_200("view-needs-login")
 
+    def test_login_required_with_method(self):
+        self.assertLoginRequired("view-needs-login", method="post")
+        self.assertLoginRequired("view-needs-login", method="put")
+        self.assertLoginRequired("view-needs-login", method="delete")
+
+    def test_login_required_with_plain_url(self):
+        self.assertLoginRequired("/view/needs-login/")
+
+    def test_login_required_with_bad_method(self):
+        with self.assertRaises(LookupError):
+            self.assertLoginRequired("view-needs-login", method="nope")
+
     def test_reverse(self):
         self.assertEqual(self.reverse("view-200"), "/view/200/")
 
@@ -578,6 +590,11 @@ class TestPlusCBViewTests(CBVTestCase):
         self.make_user("test")
         with self.login(username="test", password="password"):
             self.get_check_200("cbview-needs-login")
+
+    def test_login_required_with_plain_url(self):
+        # assertLoginRequired is inherited from BaseTestCase and still takes a
+        # URL, not a view class, even though this class overrides get()
+        self.assertLoginRequired("/cbview/needs-login/")
 
 
 class TestPlusCBDataViewTests(CBVTestCase):


### PR DESCRIPTION
Closes #202, closes #203.

## #202 — the two halves disagreed

`assertLoginRequired` resolved its url twice, under different rules:

```python
response = self.get(url, *args, **kwargs)              # tolerant: reverse w/ plain-URL fallback
reversed_url = reverse(url, args=args, kwargs=kwargs)  # intolerant: raises on a plain URL
```

A plain URL sailed through the request and then blew up on the very next line with `NoReverseMatch`. Both now go through `request()` / `_resolve_url()`, so they agree.

Note the issue's headline claim — that `assertGoodView` never reverses `url_name` — is not accurate: it delegates to `self.get()`, which reverses with a fallback. Nothing to fix there. The comment thread's point about `assertLoginRequired` is the real defect, and it's what this fixes.

## #203 — `method=`

```python
self.assertLoginRequired('my-restricted-url', method='post')
```

Keyword-only, defaulting to `"get"`. Accepts any verb `request()` supports; an unknown verb raises the existing `LookupError`. `assertRedirects` follows the 302 with a GET regardless of the original verb, so POST/PUT/DELETE behave as you'd expect.

## Backwards compatibility

Both changes are widening — every call that works today keeps working, with identical behavior. The three pre-existing `login_required` tests pass unmodified.

One edge worth naming: `method` is now consumed by the signature instead of forwarded to `reverse()`, so a URL pattern with a capture group literally named `method` could no longer receive it via this helper. That seems worth the ergonomics, but say the word and I'll rename it `http_method`.

`CBVTestCase.assertLoginRequired` is **removed**, not reimplemented. It only existed to bypass that class's view-class-taking `get()`; since the base version now calls `request()` — which `CBVTestCase` does not override — inheriting it is behavior-identical, and it picks up plain-URL and `method=` support for free. Covered by a new test.

## Tests

Four added: `method=` across post/put/delete, plain-URL, bad-verb `LookupError`, and plain-URL under `CBVTestCase`. Suite: 95 passed, 1 skipped, 2 xfailed. Docs updated.