### PR TITLE
Close the gaps between the code and the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,12 +288,29 @@ These methods build on that behavior:
 - `assertResponseContains(text, response=None, html=True, **kwargs)`
 - `assertResponseNotContains(text, response=None, html=True, **kwargs)`
 - `assertResponseHeaders(headers, response=None)` - compares only the provided headers
+- `assertResponseTemplateUsed(template_name, response=None, **kwargs)`
+- `assertResponseTemplateNotUsed(template_name, response=None, **kwargs)`
+- `assertResponseMessages(expected_messages, response=None, ordered=True)` - Django 5.0+
 
 The context helpers work against the last response:
 
 - `get_context(key)`
 - `assertInContext(key)`
 - `assertContext(key, value)`
+
+`assertResponseMessages` wraps Django's `MessagesTestMixin.assertMessages`:
+
+```python
+from django.contrib.messages import Message
+from django.contrib.messages.constants import SUCCESS
+
+def test_success_message(self):
+    self.post('my-form-view', data={'name': 'Test'})
+    self.assertResponseMessages([Message(level=SUCCESS, message='Form saved successfully!')])
+```
+
+Pass `ordered=False` if the order of the messages does not matter. On Django
+versions before 5.0 this method raises `NotImplementedError`.
 
 ## `get_check_200(url_name, *args, **kwargs)`
 
@@ -373,7 +390,7 @@ class MyFormTest(TestCase):
 
 ## Authentication Helpers
 
-### `assertLoginRequired(url_name, *args, **kwargs)`
+### `assertLoginRequired(url_name, *args, method='get', **kwargs)`
 
 This method helps you test that a given named URL requires authorization:
 
@@ -383,6 +400,25 @@ def test_auth(self):
     self.assertLoginRequired('my-restricted-object', pk=12)
     self.assertLoginRequired('my-restricted-object', slug='something')
 ```
+
+Like `self.get()` and friends, a plain URL works too when the name cannot be
+reversed:
+
+```python
+def test_auth_by_url(self):
+    self.assertLoginRequired('/restricted/')
+```
+
+Pass `method` to check a verb other than GET, which is useful for views that
+only accept writes:
+
+```python
+def test_auth_on_post(self):
+    self.assertLoginRequired('my-restricted-url', method='post')
+```
+
+`method` accepts any verb supported by `request()`: `get`, `post`, `put`,
+`patch`, `head`, `trace`, `options`, and `delete`.
 
 ### `login()` context
 
@@ -449,7 +485,7 @@ def test_something_out(self):
 
 `assertNumQueriesLessThan` also supports `verbose=True` to include the SQL in assertion failures, and `using="alias"` for multi-database projects. If you pass `func=callable`, it will execute the callable inside the query context.
 
-### `assertGoodView(url_name, *args, **kwargs)`
+### `assertGoodView(url_name, *args, verbose=False, **kwargs)`
 
 This method does a few things for you. It:
 
@@ -467,6 +503,7 @@ def test_better_than_nothing(self):
 ```
 
 If you want a different query threshold, pass `test_query_count=...` to `assertGoodView`.
+Pass `verbose=True` to include the executed SQL in the assertion failure.
 
 ## Testing DRF views
 

--- a/docs/auth_helpers.rst
+++ b/docs/auth_helpers.rst
@@ -2,7 +2,7 @@ Authentication Helpers
 ----------------------
 
 assertLoginRequired(url\_name, \*args, method='get', \*\*kwargs)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This method helps you test that a given named URL requires authorization::
 

--- a/docs/low_query_counts.rst
+++ b/docs/low_query_counts.rst
@@ -17,8 +17,8 @@ more queries than you expect::
             self.get('some-view-with-6-queries')
 
 
-assertGoodView(url\_name, \*args, \*\*kwargs)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+assertGoodView(url\_name, \*args, verbose=False, \*\*kwargs)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This method does a few things for you. It:
 

--- a/docs/methods.rst
+++ b/docs/methods.rst
@@ -77,27 +77,27 @@ put(url\_name, follow=False, \*args, \*\*kwargs)
 To support all HTTP methods
 
 patch(url\_name, follow=False, \*args, \*\*kwargs)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To support all HTTP methods
 
 head(url\_name, follow=False, \*args, \*\*kwargs)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To support all HTTP methods
 
 trace(url\_name, follow=False, \*args, \*\*kwargs)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To support all HTTP methods
 
 options(url\_name, follow=False, \*args, \*\*kwargs)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To support all HTTP methods
 
 delete(url\_name, follow=False, \*args, \*\*kwargs)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To support all HTTP methods
 
@@ -131,7 +131,7 @@ equality while we're at it. This asserts that key == value::
         self.assertContext('some-key', 'expected value')
 
 assert\_http\_XXX_\<status\_name\>(response, msg=None) - status code checking
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Another test you often need to do is check that a response has a certain
 HTTP status code. With Django's default TestCase you would write::
@@ -172,6 +172,7 @@ The ``response_###()`` methods that are deprecated, but still available for use,
 - ``response_403()``
 - ``response_404()``
 - ``response_405()``
+- ``response_409()``
 - ``response_410()``
 
 All of which take an optional Django test client response and a str msg argument that, if specified, is used as the error message when a failure occurs. Just like the ``assert_http_###_<status_name>()`` methods, these methods will use the last response if it's available.
@@ -243,6 +244,7 @@ You can check that a specific template was not used to render the last response:
 
 This is a convenience wrapper around Django's ``assertTemplateNotUsed`` that automatically
 uses ``self.last_response`` if no response is provided.
+
 assertResponseMessages(expected_messages, response=None, ordered=True)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -288,6 +290,16 @@ GETing and checking views return status 200 is a common test. This method makes 
 
     def test_even_better_status(self):
         response = self.get_check_200('my-url-name')
+
+print\_form\_errors(response\_or\_form=None)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A utility method for quickly debugging responses with form errors. It accepts
+either a response or a form instance, and defaults to ``self.last_response``::
+
+    def test_form_errors(self):
+        self.post('my-form-view', data={'name': ''})
+        self.print_form_errors()
 
 make\_user(username='testuser', password='password', perms=None)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Follow-up to #238 / #239, from a scan of the code against both doc sets. Docs only — no code changes.

The project maintains two independent full API references — `README.md` (639 lines) and `docs/*.rst` (~690 lines) — and they had drifted from the code and from each other.

## Fixed

**README missed the `assertLoginRequired` changes.** #239 updated `docs/auth_helpers.rst` for plain-URL and `method=` support but not the README, so the feature was undocumented in the place GitHub and PyPI actually render. My oversight in that PR.

**Methods documented in only one of the two:**

| Method | was in README | was in docs/ |
|---|---|---|
| `assertResponseMessages` | ❌ | ✅ |
| `assertResponseTemplateUsed` / `NotUsed` | ❌ | ✅ |
| `print_form_errors` | ✅ | ❌ |
| `response_409` | ✅ | ❌ |

`assertResponseMessages` landed in #222 and never reached the README.

**`assertGoodView(..., verbose=False, ...)`** was documented in neither; both showed the bare signature.

**Eight malformed rst section titles** whose underlines were shorter than the title text. Six pre-existing, two introduced by the heading edits in this PR and #239. Verified with `sphinx-build -W`: no title-underline warnings remain.

## Verification

`sphinx-build -W --keep-going` passes. Three warnings remain, all pre-existing and out of scope: `language = None` in conf.py, a missing `_static` directory, and `docs/modules/modules.rst` not being in any toctree.

Lint clean; 95 passed, 1 skipped, 2 xfailed.

## Not addressed

Two hand-maintained copies of the same API reference will drift again — this is the third time it has in recent history. Worth deciding whether the README should shrink to a quickstart that points at the docs, but that is a bigger call than belongs in a cleanup PR.