### PR TITLE
Prepare the 2.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changes
 
-## Unreleased
+## Version 2.5.0 - July 29th, 2026
 
   - `assertLoginRequired()` now accepts a plain URL, matching what `get()` and
     the other request helpers accept

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ push = false
 
 [tool.bumpver.file_patterns]
 "pyproject.toml" = ['current_version = "{version}"', 'version = "{version}"']
-"docs/conf.py" = ["version = '{version}'"]
+"docs/conf.py" = ['version = "{version}"']
 
 [tool.coverage.paths]
 source = ["test_plus"]


### PR DESCRIPTION
Release prep for 2.5.0. Does **not** bump the version — that stays a manual `just bump-minor` after this merges.

## `bumpver` was broken

`pyproject.toml` configured the `docs/conf.py` pattern with single quotes:

```toml
"docs/conf.py" = ["version = '{version}'"]
```

but `docs/conf.py:66` uses double quotes. Every bump aborted:

```
ERROR - No patterns matched for file 'docs/conf.py'. Invalid pattern(s)
```

Fixed by matching the file. `bumpver update --minor --dry` now cleanly rewrites all three version sites (`pyproject.toml` project version, `[tool.bumpver] current_version`, `docs/conf.py`).

## Changelog

`## Unreleased` retitled to `## Version 2.5.0 - July 29th, 2026`. There is no bumpver `file_patterns` entry for `CHANGELOG.md`, so this heading is hand-maintained — consistent with every previous release.

**Minor, not patch:** `assertLoginRequired` gained a `method` argument (new feature), and `request()` changed behavior in that a `NoReverseMatch` raised by the view now propagates instead of being swallowed. The Django 6.1 and 3.14t entries are features too.

## Remaining manual steps after merge

1. `just bump-minor ARGS=""` — commits and tags locally
2. `git push --follow-tags` — bumpver has `push = false`
3. `just release` — `uv build` + `uv publish`, run locally with your PyPI credentials (there is no publish workflow in `.github/workflows/`)

## Verification

Lint clean; 95 passed, 1 skipped, 2 xfailed. `uv build` produces a valid wheel and sdist.