### PR TITLE
Make docs/ the single source of truth for the API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,6 @@ to help your team dramatically improve your productivity.
 
 - Django 4.2 LTS, 5.1, 5.2 LTS, 6.0, and 6.1.
 
-## Documentation
-
-Full documentation is available at http://django-test-plus.readthedocs.org
-
 ## Installation
 
 ```shell
@@ -36,7 +32,8 @@ $ pip install django-test-plus
 
 ## Usage
 
-To use django-test-plus, have your tests inherit from test_plus.test.TestCase rather than the normal django.test.TestCase::
+Have your tests inherit from `test_plus.test.TestCase` rather than the normal
+`django.test.TestCase`:
 
 ```python
 from test_plus.test import TestCase
@@ -45,609 +42,71 @@ class MyViewTests(TestCase):
     ...
 ```
 
-This is sufficient to get things rolling, but you are encouraged to
-create *your own* sub-classes for your projects. This will allow you
-to add your own project-specific helper methods.
-
-For example, if you have a django project named 'myproject', you might
-create the following in `myproject/test.py`:
+That is enough to get rolling. Here is a taste of what you get — reversing
+URLs, checking status codes, and inspecting context without the boilerplate:
 
 ```python
+class MyViewTests(TestCase):
+
+    def test_the_view(self):
+        # GET a named URL, with args or kwargs if it needs them
+        self.get('my-url-name')
+        self.response_200()
+
+        # The last response and its context are stored for you
+        self.assertInContext('some-key')
+        self.assertResponseContains('<p>Hello, World!</p>')
+
+        # POST data, then check the redirect
+        self.post('my-form-view', data={'name': 'Test'})
+        self.response_302()
+
+    def test_auth(self):
+        user = self.make_user('u1')
+
+        self.assertLoginRequired('my-protected-view')
+
+        with self.login(user):
+            self.get_check_200('my-protected-view')
+
+    def test_query_count(self):
+        # 200 OK in under 50 queries, in one line
+        self.assertGoodView('my-url-name')
+```
+
+You are encouraged to create *your own* sub-class for your project so you can
+add project-specific helper methods:
+
+```python
+# myproject/test.py
 from test_plus.test import TestCase as PlusTestCase
 
 class TestCase(PlusTestCase):
     pass
 ```
 
-And then in your tests use:
-
-```python
-from myproject.test import TestCase
-
-class MyViewTests(TestCase):
-    ...
-```
-
-This import, which is similar to the way you would import Django's TestCase,
-is also valid:
-
-```python
-from test_plus import TestCase
-```
-
-## pytest Usage
-
-You can get a TestCase like object as a pytest fixture now by asking for `tp`. All of the methods below would then work in pytest functions. For
-example:
+There is a pytest fixture too — ask for `tp` and you get the same helpers:
 
 ```python
 def test_url_reverse(tp):
-    expected_url = '/api/'
-    reversed_url = tp.reverse('api')
-    assert expected_url == reversed_url
+    assert tp.reverse('api') == '/api/'
 ```
 
-The pytest plugin is auto-registered via `pytest11`, so no extra configuration is required beyond installing the package and pytest-django. In addition to `tp` and `tp_api`, the plugin also provides a raw `api_client` fixture:
-
-```python
-def test_api_client(api_client):
-    response = api_client.get("/api/")
-    assert response.status_code == 200
-```
-
-The `tp_api` fixture will provide a `TestCase` that uses django-rest-framework's `APIClient()`:
-
-```python
-def test_url_reverse(tp_api):
-    response = tp_api.client.post("myapi", format="json")
-    assert response.status_code == 200
-```
-
-## Methods
-
-### `reverse(url_name, *args, **kwargs)`
-
-When testing views you often find yourself needing to reverse the URL's name. With django-test-plus there is no need for the `from django.core.urlresolvers import reverse` boilerplate. Instead, use:
-
-```python
-def test_something(self):
-    url = self.reverse('my-url-name')
-    slug_url = self.reverse('name-takes-a-slug', slug='my-slug')
-    pk_url = self.reverse('name-takes-a-pk', pk=12)
-```
-
-As you can see our reverse also passes along any args or kwargs you need
-to pass in.
-
-## `get(url_name, follow=True, *args, **kwargs)`
-
-Another thing you do often is HTTP get urls. Our `get()` method
-assumes you are passing in a named URL with any args or kwargs necessary
-to reverse the url_name.
-If needed, place kwargs for `TestClient.get()` in an 'extra' dictionary.:
-
-```python
-def test_get_named_url(self):
-    response = self.get('my-url-name')
-    # Get XML data via AJAX request
-    xml_response = self.get(
-        'my-url-name',
-        extra={'HTTP_X_REQUESTED_WITH': 'XMLHttpRequest'})
-```
-
-When using this get method two other things happen for you: we store the
-last response in `self.last_response` and the response's Context in `self.context`.
-
-So instead of:
-
-```python
-def test_default_django(self):
-    response = self.client.get(reverse('my-url-name'))
-    self.assertTrue('foo' in response.context)
-    self.assertEqual(response.context['foo'], 12)
-```
-
-You can write:
-
-```python
-def test_testplus_get(self):
-    self.get('my-url-name')
-    self.assertInContext('foo')
-    self.assertEqual(self.context['foo'], 12)
-```
-
-It's also smart about already reversed URLs, so you can be lazy and do:
-
-```python
-def test_testplus_get(self):
-    url = self.reverse('my-url-name')
-    self.get(url)
-    self.response_200()
-```
-
-If you need to pass query string parameters to your url name, you can do so like this. Assuming the name 'search' maps to '/search/' then:
-
-```python
-def test_testplus_get_query(self):
-    self.get('search', data={'query': 'testing'})
-```
-
-Would GET `/search/?query=testing`.
-
-## `post(url_name, data, follow=True, *args, **kwargs)`
-
-Our `post()` method takes a named URL, an optional dictionary of data you wish
-to post and any args or kwargs necessary to reverse the url_name.
-If needed, place kwargs for `TestClient.post()` in an 'extra' dictionary.:
-
-```python
-def test_post_named_url(self):
-    response = self.post('my-url-name', data={'coolness-factor': 11.0},
-                         extra={'HTTP_X_REQUESTED_WITH': 'XMLHttpRequest'})
-```
-
-*NOTE* Along with the frequently used get and post, we support all of the HTTP verbs such as put, patch, head, trace, options, and delete in the same fashion.
-
-## `get_context(key)`
-
-Often you need to get things out of the template context:
-
-```python
-def test_context_data(self):
-    self.get('my-view-with-some-context')
-    slug = self.get_context('slug')
-```
-
-## `assertInContext(key)`
-
-You can ensure a specific key exists in the last response's context by
-using:
-
-```python
-def test_in_context(self):
-    self.get('my-view-with-some-context')
-    self.assertInContext('some-key')
-```
-
-## `assertContext(key, value)`
-
-We can get context values and ensure they exist, but we can also test
-equality while we're at it. This asserts that key == value:
-
-```python
-def test_in_context(self):
-    self.get('my-view-with-some-context')
-    self.assertContext('some-key', 'expected value')
-```
-
-## `assert_http_###_<status_name>(response, msg=None)` - status code checking
-
-Another test you often need to do is check that a response has a certain
-HTTP status code. With Django's default TestCase you would write:
-
-```python
-from django.core.urlresolvers import reverse
-
-def test_status(self):
-    response = self.client.get(reverse('my-url-name'))
-    self.assertEqual(response.status_code, 200)
-```
-
-With django-test-plus you can shorten that to be:
-
-```python
-def test_better_status(self):
-    response = self.get('my-url-name')
-    self.assert_http_200_ok(response)
-```
-
-Django-test-plus provides a majority of the status codes assertions for you. The status assertions
-can be found in their own [mixin](https://github.com/revsys/django-test-plus/blob/main/test_plus/status_codes.py)
-and should be searchable if you're using an IDE like pycharm. It should be noted that in previous
-versions, django-test-plus had assertion methods in the pattern of `response_###()`, which are still
-available but have since been deprecated. See below for a list of those methods.
-
-Each of the assertion methods takes an optional Django test client `response` and a string `msg` argument
-that, if specified, is used as the error message when a failure occurs. The methods,
-`assert_http_301_moved_permanently` and `assert_http_302_found` also take an optional `url` argument that
-if passed, will check to make sure the `response.url` matches.
-
-If it's available, the `assert_http_###_<status_name>` methods will use the last response. So you
-can do:
-
-```python
-def test_status(self):
-    self.get('my-url-name')
-    self.assert_http_200_ok()
-```
-
-Which is a bit shorter.
-
-The `response_###()` methods that are deprecated, but still available for use, include:
-
-- `response_200()`
-- `response_201()`
-- `response_204()`
-- `response_301()`
-- `response_302()`
-- `response_400()`
-- `response_401()`
-- `response_403()`
-- `response_404()`
-- `response_405()`
-- `response_409()`
-- `response_410()`
-
-All of which take an optional Django test client response and a str msg argument that, if specified, is used as the error message when a failure occurs. Just like the `assert_http_###_<status_name>()` methods, these methods will use the last response if it's available.
-
-## Response helpers and stored context
-
-Every request made through `test_plus` stores the last response on `self.last_response` and the template context on `self.context`.
-These methods build on that behavior:
-
-- `assertResponseContains(text, response=None, html=True, **kwargs)`
-- `assertResponseNotContains(text, response=None, html=True, **kwargs)`
-- `assertResponseHeaders(headers, response=None)` - compares only the provided headers
-- `assertResponseTemplateUsed(template_name, response=None, **kwargs)`
-- `assertResponseTemplateNotUsed(template_name, response=None, **kwargs)`
-- `assertResponseMessages(expected_messages, response=None, ordered=True)` - Django 5.0+
-
-The context helpers work against the last response:
-
-- `get_context(key)`
-- `assertInContext(key)`
-- `assertContext(key, value)`
-
-`assertResponseMessages` wraps Django's `MessagesTestMixin.assertMessages`:
-
-```python
-from django.contrib.messages import Message
-from django.contrib.messages.constants import SUCCESS
-
-def test_success_message(self):
-    self.post('my-form-view', data={'name': 'Test'})
-    self.assertResponseMessages([Message(level=SUCCESS, message='Form saved successfully!')])
-```
-
-Pass `ordered=False` if the order of the messages does not matter. On Django
-versions before 5.0 this method raises `NotImplementedError`.
-
-## `get_check_200(url_name, *args, **kwargs)`
-
-GETing and checking views return status 200 is a common test. This method makes it more convenient::
-
-```python
-def test_even_better_status(self):
-    response = self.get_check_200('my-url-name')
-```
-
-## make_user(username='testuser', password='password', perms=None)
-
-When testing out views you often need to create various users to ensure
-all of your logic is safe and sound. To make this process easier, this
-method will create a user for you:
-
-```python
-def test_user_stuff(self)
-    user1 = self.make_user('u1')
-    user2 = self.make_user('u2')
-```
-
-If creating a User in your project is more complicated, say for example
-you removed the `username` field from the default Django Auth model,
-you can provide a [Factory
-Boy](https://factoryboy.readthedocs.org/en/latest/) factory to create
-it or override this method on your own sub-class.
-
-To use a Factory Boy factory, create your class like this::
-
-```python
-from test_plus.test import TestCase
-from .factories import UserFactory
-
-
-class MySpecialTest(TestCase):
-    user_factory = UserFactory
-
-    def test_special_creation(self):
-        user1 = self.make_user('u1')
-```
-
-**NOTE:** Users created by this method will have their password
-set to the string 'password' by default, in order to ease testing.
-If you need a specific password, override the `password` parameter.
-
-You can also pass in user permissions by passing in a string of
-'`<app_name>.<perm name>`' or '`<app_name>.*`'.  For example:
-
-```python
-user2 = self.make_user(perms=['myapp.create_widget', 'otherapp.*'])
-```
-
-## `print_form_errors(response_or_form=None)`
-
-When debugging a failing test for a view with a form, this method helps you
-quickly look at any form errors.
-
-Example usage:
-
-```python
-class MyFormTest(TestCase):
-
-    self.post('my-url-name', data={})
-    self.print_form_errors()
-
-    # or
-
-    resp = self.post('my-url-name', data={})
-    self.print_form_errors(resp)
-
-    # or
-
-    form = MyForm(data={})
-    self.print_form_errors(form)
-```
-
-## Authentication Helpers
-
-### `assertLoginRequired(url_name, *args, method='get', **kwargs)`
-
-This method helps you test that a given named URL requires authorization:
-
-```python
-def test_auth(self):
-    self.assertLoginRequired('my-restricted-url')
-    self.assertLoginRequired('my-restricted-object', pk=12)
-    self.assertLoginRequired('my-restricted-object', slug='something')
-```
-
-Like `self.get()` and friends, a plain URL works too when the name cannot be
-reversed:
-
-```python
-def test_auth_by_url(self):
-    self.assertLoginRequired('/restricted/')
-```
-
-Pass `method` to check a verb other than GET, which is useful for views that
-only accept writes:
-
-```python
-def test_auth_on_post(self):
-    self.assertLoginRequired('my-restricted-url', method='post')
-```
-
-`method` accepts any verb supported by `request()`: `get`, `post`, `put`,
-`patch`, `head`, `trace`, `options`, and `delete`.
-
-### `login()` context
-
-Along with ensuring a view requires login and creating users, the next
-thing you end up doing is logging in as various users to test your
-restriction logic:
-
-```python
-def test_restrictions(self):
-    user1 = self.make_user('u1')
-    user2 = self.make_user('u2')
-
-    self.assertLoginRequired('my-protected-view')
-
-    with self.login(username=user1.username, password='password'):
-        response = self.get('my-protected-view')
-        # Test user1 sees what they should be seeing
-
-    with self.login(username=user2.username, password='password'):
-        response = self.get('my-protected-view')
-        # Test user2 see what they should be seeing
-```
-
-Since we're likely creating our users using `make_user()` from above,
-the login context assumes the password is 'password' unless specified
-otherwise. Therefore you you can do:
-
-```python
-def test_restrictions(self):
-    user1 = self.make_user('u1')
-
-    with self.login(username=user1.username):
-        response = self.get('my-protected-view')
-```
-
-We can also derive the username if we're using `make_user()` so we can
-shorten that up even further like this:
-
-```python
-def test_restrictions(self):
-    user1 = self.make_user('u1')
-
-    with self.login(user1):
-        response = self.get('my-protected-view')
-```
-
-## Ensuring low query counts
-
-### `assertNumQueriesLessThan(number)` - context
-
-Django provides
-[`assertNumQueries`](https://docs.djangoproject.com/en/1.8/topics/testing/tools/#django.test.TransactionTestCase.assertNumQueries)
-which is great when your code generates a specific number of
-queries. However, if this number varies due to the nature of your data, with
-this method you can still test to ensure the code doesn't start producing a ton
-more queries than you expect:
-
-```python
-def test_something_out(self):
-
-    with self.assertNumQueriesLessThan(7):
-        self.get('some-view-with-6-queries')
-```
-
-`assertNumQueriesLessThan` also supports `verbose=True` to include the SQL in assertion failures, and `using="alias"` for multi-database projects. If you pass `func=callable`, it will execute the callable inside the query context.
-
-### `assertGoodView(url_name, *args, verbose=False, **kwargs)`
-
-This method does a few things for you. It:
-
-- Retrieves the name URL
-- Ensures the view does not generate more than 50 queries
-- Ensures the response has status code 200
-- Returns the response
-
-Often a wide, sweeping test like this is better than no test at all. You
-can use it like this:
-
-```python
-def test_better_than_nothing(self):
-    response = self.assertGoodView('my-url-name')
-```
-
-If you want a different query threshold, pass `test_query_count=...` to `assertGoodView`.
-Pass `verbose=True` to include the executed SQL in the assertion failure.
-
-## Testing DRF views
-
-To take advantage of the convenience of DRF's test client, you can create a subclass of `TestCase` and set the `client_class` property:
-
-```python
-from test_plus import TestCase
-from rest_framework.test import APIClient
-
-
-class APITestCase(TestCase):
-    client_class = APIClient
-```
-
-For convenience, `test_plus` ships with `APITestCase`, which does just that:
-
-```python
-from test_plus import APITestCase
-
-
-class MyAPITestCase(APITestCase):
-
-    def test_post(self):
-        data = {'testing': {'prop': 'value'}}
-        self.post('view-json', data=data, extra={'format': 'json'})
-        self.assert_http_200_ok()
-```
-
-Note that using `APITestCase` requires Django >= 1.8 and having installed `django-rest-framework`.
-
-## Testing class-based "generic" views
-
-The TestCase methods `get()` and `post()` work for both function-based
-and class-based views. However, in doing so they invoke Django's
-URL resolution, middleware, template processing, and decorator systems.
-For integration testing this is desirable, as you want to ensure your
-URLs resolve properly, view permissions are enforced, etc.
-For unit testing this is costly because all these Django request/response
-systems are invoked in addition to your method, and they typically do not
-affect the end result.
-
-Class-based views (derived from Django's `generic.models.View` class)
-contain methods and mixins which makes granular unit testing (more) feasible.
-Quite often your usage of a generic view class comprises an override
-of an existing method. Invoking the entire view and the Django request/response
-stack is a waste of time when you really want to call the overridden
-method directly and test the result.
-
-CBVTestCase to the rescue!
-
-As with TestCase above, have your tests inherit
-from test_plus.test.CBVTestCase rather than TestCase like so:
-
-```python
-from test_plus.test import CBVTestCase
-
-class MyViewTests(CBVTestCase):
-```
-
-## Methods
-
-### `get_instance(cls, initkwargs=None, request=None, *args, **kwargs)`
-
-This core method simplifies the instantiation of your class, giving you
-a way to invoke class methods directly.
-
-Returns an instance of `cls`, initialized with `initkwargs`.
-Sets `request`, `args`, and `kwargs` attributes on the class instance.
-`args` and `kwargs` are the same values you would pass to `reverse()`.
-
-Sample usage:
-
-```python
-from django.views import generic
-from test_plus.test import CBVTestCase
-
-class MyClass(generic.DetailView)
-
-    def get_context_data(self, **kwargs):
-        kwargs['answer'] = 42
-        return kwargs
-
-class MyTests(CBVTestCase):
-
-    def test_context_data(self):
-        my_view = self.get_instance(MyClass, {'object': some_object})
-        context = my_view.get_context_data()
-        self.assertEqual(context['answer'], 42)
-```
-
-### `get(cls, initkwargs=None, *args, **kwargs)`
-
-Invokes `cls.get()` and returns the response, rendering template if possible.
-Builds on the `CBVTestCase.get_instance()` foundation.
-
-All test_plus.test.TestCase methods are valid, so the following works:
-
-```python
-response = self.get(MyClass)
-self.assertContext('my_key', expected_value)
-```
-
-All test_plus TestCase side-effects are honored and all test_plus
-TestCase assertion methods work with `CBVTestCase.get()`.
-
-**NOTE:** This method bypasses Django's middleware, and therefore context
-variables created by middleware are not available. If this affects your
-template/context testing, you should use TestCase instead of CBVTestCase.
-
-### `post(cls, data=None, initkwargs=None, *args, **kwargs)`
-
-Invokes `cls.post()` and returns the response, rendering template if possible.
-Builds on the `CBVTestCase.get_instance()` foundation.
-
-Example:
-
-```python
-response = self.post(MyClass, data={'search_term': 'revsys'})
-self.response_200(response)
-self.assertContext('company_name', 'RevSys')
-```
-
-All test_plus TestCase side-effects are honored and all test_plus
-TestCase assertion methods work with `CBVTestCase.post()`.
-
-**NOTE:** This method bypasses Django's middleware, and therefore context
-variables created by middleware are not available. If this affects your
-template/context testing you should use TestCase instead of CBVTestCase.
-
-### `get_check_200(cls, initkwargs=None, *args, **kwargs)`
-
-Works just like `TestCase.get_check_200()`.
-Caller must provide a view class instead of a URL name or path parameter.
-
-All test_plus TestCase side-effects are honored and all test_plus
-TestCase assertion methods work with `CBVTestCase.post()`.
-
-### `assertGoodView(cls, initkwargs=None, *args, **kwargs)`
-
-Works just like `TestCase.assertGoodView()`.
-Caller must provide a view class instead of a URL name or path parameter.
-
-All test_plus TestCase side-effects are honored and all test_plus
-TestCase assertion methods work with `CBVTestCase.post()`.
+## Documentation
+
+**Full documentation, including the complete method reference, is available at
+[django-test-plus.readthedocs.org](http://django-test-plus.readthedocs.org).**
+
+- [Usage](https://django-test-plus.readthedocs.io/en/latest/usage.html) —
+  including pytest fixtures and testing DRF views
+- [Methods](https://django-test-plus.readthedocs.io/en/latest/methods.html) —
+  requests, status code assertions, response and context helpers, `make_user`
+- [Authentication helpers](https://django-test-plus.readthedocs.io/en/latest/auth_helpers.html) —
+  `assertLoginRequired` and the `login()` context
+- [Ensuring low query counts](https://django-test-plus.readthedocs.io/en/latest/low_query_counts.html) —
+  `assertNumQueriesLessThan` and `assertGoodView`
+- [Testing class-based views](https://django-test-plus.readthedocs.io/en/latest/cbvtestcase.html)
+- [Disable logging](https://django-test-plus.readthedocs.io/en/latest/disable_logging.html)
 
 ## Development
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,7 +72,7 @@ release = version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -145,7 +145,7 @@ html_theme = "alabaster"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+html_static_path = []
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ Contents:
    low_query_counts
    cbvtestcase
    disable_logging
+   modules/modules
 
 
 

--- a/docs/methods.rst
+++ b/docs/methods.rst
@@ -291,6 +291,18 @@ GETing and checking views return status 200 is a common test. This method makes 
     def test_even_better_status(self):
         response = self.get_check_200('my-url-name')
 
+assertRedirects(response, expected\_url, ...) and assertURLEqual(url1, url2)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Both are Django's own assertions, re-exported so they are available on
+``TestCase`` without an extra import.
+
+``assertURLEqual`` compares two URLs for equality, ignoring the ordering of
+query string parameters::
+
+    def test_urls_match(self):
+        self.assertURLEqual('/search/?a=1&b=2', '/search/?b=2&a=1')
+
 print\_form\_errors(response\_or\_form=None)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -45,6 +45,14 @@ example::
         reversed_url = tp.reverse('api')
         assert expected_url == reversed_url
 
+The pytest plugin is auto-registered via ``pytest11``, so no extra configuration
+is required beyond installing the package and pytest-django. In addition to
+``tp`` and ``tp_api``, the plugin also provides a raw ``api_client`` fixture::
+
+    def test_api_client(api_client):
+        response = api_client.get("/api/")
+        assert response.status_code == 200
+
 The ``tp_api`` fixture will provide a ``TestCase`` that uses django-rest-framework's `APIClient()`::
 
     def test_url_reverse(tp_api):


### PR DESCRIPTION
Follow-up to #240, which fixed that round of drift but left the cause in place.

`README.md` (639 lines) and `docs/*.rst` (~690 lines) were two independent full API references. They have now drifted three times in recent history — `assertResponseMessages` landed in only `docs/`, `print_form_errors` and `response_409` in only README, `assertGoodView`'s `verbose=` in neither. Keeping two hand-maintained copies in sync is not a thing that works.

**`docs/` is now canonical. README is a quickstart: 639 lines → 135.**

## What the README keeps

Rationale, support matrix, installation, a single worked example showing the core loop (`get` → `response_200` → context/response assertions, `make_user` + `login`, `assertGoodView`), the sub-classing pattern, a two-line pytest taste, and a linked index into the docs. Plus Development / running tests / Keep in touch, unchanged.

The removed material is not lost — every section had an equivalent in `docs/`, which I verified mechanically rather than by eye:

```python
names = public methods of BaseTestCase/TestCase/CBVTestCase   # 44
missing = [n for n in names if n not in docs_text]
```

## What moved into `docs/`

- The `pytest11` auto-registration note and the `api_client` fixture, which README had and `docs/usage.rst` did not
- `assertRedirects` and `assertURLEqual` — documented in neither file before

## Sphinx warnings

The docs build now passes under `-W`. Three long-standing warnings are cleared: `language = None` → `"en"`, `html_static_path` pointed at a `_static/` directory that does not exist, and `docs/modules/modules.rst` was not in any toctree.

**Correction to #240:** I claimed there that `sphinx-build -W --keep-going` passed. It did not — I read an exit code through a pipe. The plain build passed; `-W` exited 1 on those three warnings. It genuinely passes now.

## Verification

- `sphinx-build -W --keep-going` exits 0
- The README's example is not hand-waved — I ran it as a real test case against the test project's views; all three test methods pass
- Lint clean; 95 passed, 1 skipped, 2 xfailed

## Note

The README is what PyPI renders, so this materially shortens the project's PyPI landing page. That is the intended trade — it now sells the library and points at the reference, rather than being the reference. Easy to revert if you dislike how it reads.