### PR TITLE
Show pytest examples in the docs alongside the unittest ones

### DIFF
--- a/docs/auth_helpers.rst
+++ b/docs/auth_helpers.rst
@@ -26,6 +26,12 @@ only accept writes::
 ``method`` accepts any verb supported by ``request()``: ``get``, ``post``,
 ``put``, ``patch``, ``head``, ``trace``, ``options``, and ``delete``.
 
+The same thing with the pytest ``tp`` fixture (see :ref:`pytest-usage`)::
+
+    def test_auth(tp):
+        tp.assertLoginRequired('my-restricted-url')
+        tp.assertLoginRequired('my-restricted-url', method='post')
+
 login context
 ~~~~~~~~~~~~~
 
@@ -65,3 +71,13 @@ shorten that up even further like this::
 
         with self.login(user1):
             response = self.get('my-protected-view')
+
+The login context works the same way on the pytest ``tp`` fixture. Because
+``tp`` does not set up database access on its own, ask for pytest-django's
+``db`` fixture in any test that creates a user::
+
+    def test_restrictions(tp, db):
+        user1 = tp.make_user('u1')
+
+        with tp.login(user1):
+            response = tp.get('my-protected-view')

--- a/docs/low_query_counts.rst
+++ b/docs/low_query_counts.rst
@@ -32,3 +32,14 @@ can use it like this::
 
     def test_better_than_nothing(self):
         response = self.assertGoodView('my-url-name')
+
+Both helpers are available on the pytest ``tp`` fixture too (see
+:ref:`pytest-usage`). Both count queries, so they need database access — ask
+for pytest-django's ``db`` fixture alongside ``tp``::
+
+    def test_better_than_nothing(tp, db):
+        response = tp.assertGoodView('my-url-name')
+
+    def test_something_out(tp, db):
+        with tp.assertNumQueriesLessThan(7):
+            tp.get('some-view-with-6-queries')

--- a/docs/methods.rst
+++ b/docs/methods.rst
@@ -1,6 +1,11 @@
 Methods
 -------
 
+These examples are written in the unittest style, on a ``TestCase`` subclass.
+Every method here is also available on the pytest ``tp`` fixture — write
+``tp.get('my-url-name')`` where these read ``self.get('my-url-name')``. See
+:ref:`pytest-usage` for the details.
+
 reverse(url\_name, \*args, \*\*kwargs)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -306,12 +311,21 @@ query string parameters::
 print\_form\_errors(response\_or\_form=None)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A utility method for quickly debugging responses with form errors. It accepts
-either a response or a form instance, and defaults to ``self.last_response``::
+When debugging a failing test for a view with a form, this method helps you
+quickly look at any form errors. It accepts either a response or a form
+instance, and defaults to ``self.last_response``::
 
     def test_form_errors(self):
-        self.post('my-form-view', data={'name': ''})
+        self.post('my-form-view', data={})
         self.print_form_errors()
+
+    def test_form_errors_explicit_response(self):
+        resp = self.post('my-form-view', data={})
+        self.print_form_errors(resp)
+
+    def test_form_errors_from_a_form(self):
+        form = MyForm(data={})
+        self.print_form_errors(form)
 
 make\_user(username='testuser', password='password', perms=None)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -34,6 +34,8 @@ is also valid::
 
     from test_plus import TestCase
 
+.. _pytest-usage:
+
 pytest Usage
 ~~~~~~~~~~~~
 
@@ -44,6 +46,46 @@ example::
         expected_url = '/api/'
         reversed_url = tp.reverse('api')
         assert expected_url == reversed_url
+
+Everything documented in :doc:`methods`, :doc:`auth_helpers`,
+:doc:`low_query_counts` and :doc:`cbvtestcase` is available on ``tp``. Anywhere
+those pages write ``self.<method>()``, a pytest test writes ``tp.<method>()``.
+The same test written both ways::
+
+    # unittest style
+    from test_plus.test import TestCase
+
+    class MyViewTests(TestCase):
+
+        def test_the_view(self):
+            self.get('my-url-name')
+            self.response_200()
+            self.assertInContext('some-key')
+
+        def test_auth(self):
+            user = self.make_user('u1')
+            self.assertLoginRequired('my-protected-view')
+            with self.login(user):
+                self.get_check_200('my-protected-view')
+
+    # pytest style
+    def test_the_view(tp):
+        tp.get('my-url-name')
+        tp.response_200()
+        tp.assertInContext('some-key')
+
+    def test_auth(tp, db):
+        user = tp.make_user('u1')
+        tp.assertLoginRequired('my-protected-view')
+        with tp.login(user):
+            tp.get_check_200('my-protected-view')
+
+Note that ``tp`` does not manage database access for you the way
+``django.test.TestCase`` does. Ask for pytest-django's ``db`` fixture (or apply
+``@pytest.mark.django_db``) in any test that touches the database. That
+includes ``make_user()`` and the ``login()`` context, and also the query
+counting helpers ``assertNumQueriesLessThan()`` and ``assertGoodView()``, which
+open a database connection in order to count.
 
 The pytest plugin is auto-registered via ``pytest11``, so no extra configuration
 is required beyond installing the package and pytest-django. In addition to

--- a/test_project/test_app/tests/test_doc_examples.py
+++ b/test_project/test_app/tests/test_doc_examples.py
@@ -1,0 +1,30 @@
+"""Guards the pytest examples in docs/usage.rst, auth_helpers.rst and
+low_query_counts.rst. If you change those examples, change these too.
+"""
+
+def test_the_view(tp):
+    tp.get('view-context-with')
+    tp.response_200()
+    tp.assertInContext('testvalue')
+
+def test_auth(tp, db):
+    user = tp.make_user('u1')
+    tp.assertLoginRequired('view-needs-login')
+    with tp.login(user):
+        tp.get_check_200('view-needs-login')
+
+def test_auth_methods(tp):
+    tp.assertLoginRequired('view-needs-login')
+    tp.assertLoginRequired('view-needs-login', method='post')
+
+def test_restrictions(tp, db):
+    user1 = tp.make_user('u1')
+    with tp.login(user1):
+        tp.get('view-needs-login')
+
+def test_better_than_nothing(tp, db):
+    tp.assertGoodView('view-200')
+
+def test_query_ctx(tp, db):
+    with tp.assertNumQueriesLessThan(7):
+        tp.get('view-200')

--- a/test_project/test_app/tests/test_doc_examples.py
+++ b/test_project/test_app/tests/test_doc_examples.py
@@ -2,29 +2,35 @@
 low_query_counts.rst. If you change those examples, change these too.
 """
 
+
 def test_the_view(tp):
-    tp.get('view-context-with')
+    tp.get("view-context-with")
     tp.response_200()
-    tp.assertInContext('testvalue')
+    tp.assertInContext("testvalue")
+
 
 def test_auth(tp, db):
-    user = tp.make_user('u1')
-    tp.assertLoginRequired('view-needs-login')
+    user = tp.make_user("u1")
+    tp.assertLoginRequired("view-needs-login")
     with tp.login(user):
-        tp.get_check_200('view-needs-login')
+        tp.get_check_200("view-needs-login")
+
 
 def test_auth_methods(tp):
-    tp.assertLoginRequired('view-needs-login')
-    tp.assertLoginRequired('view-needs-login', method='post')
+    tp.assertLoginRequired("view-needs-login")
+    tp.assertLoginRequired("view-needs-login", method="post")
+
 
 def test_restrictions(tp, db):
-    user1 = tp.make_user('u1')
+    user1 = tp.make_user("u1")
     with tp.login(user1):
-        tp.get('view-needs-login')
+        tp.get("view-needs-login")
+
 
 def test_better_than_nothing(tp, db):
-    tp.assertGoodView('view-200')
+    tp.assertGoodView("view-200")
+
 
 def test_query_ctx(tp, db):
     with tp.assertNumQueriesLessThan(7):
-        tp.get('view-200')
+        tp.get("view-200")


### PR DESCRIPTION
Two things: what the README trim in #243 actually lost, and pytest coverage in the docs.

## Did the README trim lose anything?

I checked mechanically rather than by eye — extracted all 118 code lines from the pre-#243 README and looked for each in `docs/` or the new README. 14 had no match. Of those:

- **12 were false positives** — the CBV examples, where docs use `MyViewClass`/`special_value` and the README used `MyClass`/`answer`. The docs version is the richer of the two.
- **1 was a formatting variant** of the `assertResponseMessages` example, which docs cover more fully.
- **1 was a real loss:** `print_form_errors` had three usage forms in the README (implicit `last_response`, explicit response, bare form instance) and docs showed only one. Restored.

## pytest examples

Every helper works on `tp`, but the docs showed only the unittest style, leaving pytest users to infer the mapping. Added:

- A side-by-side in `usage.rst` of the same two tests written both ways, under a new `pytest-usage` anchor
- A pointer at the top of `methods.rst` — `self.get(...)` → `tp.get(...)`
- `tp` variants for `assertLoginRequired`, the `login()` context, `assertGoodView`, and `assertNumQueriesLessThan`

## A gotcha worth documenting

`tp` does not set up database access the way `django.test.TestCase` does. `make_user()` and the `login()` context need pytest-django's `db` fixture — and so do `assertNumQueriesLessThan()` and `assertGoodView()`, which is the surprising part: they open a connection in order to count queries, so they need `db` even when the view under test touches nothing.

```
RuntimeError: Database access not allowed, use the "django_db" mark,
or the "db" or "transactional_db" fixtures to enable it.
```

## These examples are tested

`test_doc_examples.py` runs every pytest example the docs show. This is not ceremony — **two of the examples were wrong when I first wrote them** (the query-count ones, missing `db`), and running them is what caught it. The examples can now break the build instead of quietly misleading someone.

## Verification

`sphinx-build -W --keep-going` exits 0. Lint clean. 101 passed, 1 skipped, 2 xfailed (was 95 — six new).