### PR TITLE
Raise NoPreviousResponse when there is no response to inspect

### DIFF
--- a/test_plus/test.py
+++ b/test_plus/test.py
@@ -178,10 +178,13 @@ class BaseTestCase(StatusCodeAssertionMixin):
         return self.request("delete", url_name, *args, **kwargs)
 
     def _which_response(self, response=None):
-        if response is None and self.last_response is not None:
-            return self.last_response
-        else:
+        if response is not None:
             return response
+
+        if self.last_response is None:
+            raise NoPreviousResponse("There isn't a previous response to query")
+
+        return self.last_response
 
     def _assert_response_code(self, status_code, response=None, msg=None):
         response = self._which_response(response)

--- a/test_project/test_app/tests/test_unittests.py
+++ b/test_project/test_app/tests/test_unittests.py
@@ -504,6 +504,23 @@ class TestPlusViewTests(TestCase):
         with self.assertRaises(NoPreviousResponse):
             self.get_context("testvalue")
 
+    def test_no_response_status_code(self):
+        # Previously an AttributeError on NoneType, unlike the context helpers
+        with self.assertRaises(NoPreviousResponse):
+            self.response_200()
+
+    def test_no_response_assert_http_status(self):
+        with self.assertRaises(NoPreviousResponse):
+            self.assert_http_200_ok()
+
+    def test_no_response_contains(self):
+        with self.assertRaises(NoPreviousResponse):
+            self.assertResponseContains("anything")
+
+    def test_no_response_headers(self):
+        with self.assertRaises(NoPreviousResponse):
+            self.assertResponseHeaders({"X-Test": "1"})
+
     def test_get_is_ajax(self):
         response = self.get("view-is-ajax", extra={"HTTP_X_REQUESTED_WITH": "XMLHttpRequest"})
         self.response_200(response)


### PR DESCRIPTION
Found while auditing the package.

## The bug

`BaseTestCase._which_response` resolves "the response the caller meant" for every response helper — all the `assert_http_*` methods, the deprecated `response_###` ones, `assertResponseContains`, `assertResponseHeaders`, `assertResponseMessages`, and friends.

```python
def _which_response(self, response=None):
    if response is None and self.last_response is not None:
        return self.last_response
    else:
        return response    # <- returns None when there is no response at all
```

Call any of those before making a request and you get:

```
AttributeError: 'NoneType' object has no attribute 'status_code'
```

pointing into `test_plus/test.py`, which tells the reader nothing about what they did wrong.

The inconsistency is the giveaway: `get_context()` raises `NoPreviousResponse("There isn't a previous response to query")` for precisely this situation, and `NoPreviousResponse` is already a public exported exception with tests. The response helpers just never used it.

## The fix

```python
if response is not None:
    return response
if self.last_response is None:
    raise NoPreviousResponse("There isn't a previous response to query")
return self.last_response
```

## Compatibility

This only changes which exception an **already-failing** test reports — `AttributeError` becomes `NoPreviousResponse`. No passing test changes behavior. A caller catching `AttributeError` here would be catching a crash, not an API.

## Tests

Four added, covering the paths through `_which_response`: `response_200()`, `assert_http_200_ok()`, `assertResponseContains()`, `assertResponseHeaders()`. All four fail on `main` with the `AttributeError`. 105 passed, 1 skipped, 2 xfailed.

## Not fixed, deliberately

While looking at this I also checked `assertGoodView`'s `test_query_count`, which I had flagged as a possible kwarg collision. Making it keyword-only would **not** help: `kwargs.pop("test_query_count", 50)` already behaves exactly like a keyword-only parameter, so a URL kwarg of that name is swallowed either way. The only real fix is renaming the parameter, which is breaking. Left alone.