### PR TITLE
Remove shims for versions we no longer support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Free Threading :: 3 - Stable",
 ]
-dependencies = ["packaging"]
+dependencies = []
 requires-python = ">=3.10"
 
 [project.readme]

--- a/test_plus/compat.py
+++ b/test_plus/compat.py
@@ -1,9 +1,7 @@
 from django.test import TestCase as DjangoTestCase
 
-try:
-    from django.urls import NoReverseMatch, reverse
-except ImportError:
-    from django.core.urlresolvers import reverse, NoReverseMatch  # noqa
+# Re-exported for convenience so callers can import them from test_plus.compat.
+from django.urls import NoReverseMatch, reverse  # noqa: F401
 
 try:
     import rest_framework  # noqa
@@ -25,12 +23,7 @@ def get_api_client():
     return APIClient
 
 
-if hasattr(DjangoTestCase, "assertURLEqual"):
-    assertURLEqual = DjangoTestCase.assertURLEqual
-else:
-
-    def assertURLEqual(t, url1, url2, msg_prefix=""):
-        raise NotImplementedError("Your version of Django does not support `assertURLEqual`")
+assertURLEqual = DjangoTestCase.assertURLEqual
 
 
 try:

--- a/test_plus/test.py
+++ b/test_plus/test.py
@@ -1,10 +1,3 @@
-import django
-
-try:
-    from packaging.version import parse as parse_version
-except ImportError:
-    from distutils.version import LooseVersion as parse_version
-
 from functools import partial
 
 from django.conf import settings
@@ -25,11 +18,6 @@ from .compat import NoReverseMatch, assertMessages, assertURLEqual, get_api_clie
 
 class NoPreviousResponse(Exception):
     pass
-
-
-# Build a real context
-
-CAPTURE = True
 
 
 class _AssertNumQueriesLessThanContext(CaptureQueriesContext):
@@ -163,13 +151,7 @@ class BaseTestCase(StatusCodeAssertionMixin):
         return self.request("head", url_name, *args, **kwargs)
 
     def trace(self, url_name, *args, **kwargs):
-        if parse_version(django.get_version()) >= parse_version("1.8.2"):
-            return self.request("trace", url_name, *args, **kwargs)
-        else:
-            raise LookupError(
-                "client.trace is not available for your version of django. Please\
-                               update your django version."
-            )
+        return self.request("trace", url_name, *args, **kwargs)
 
     def options(self, url_name, *args, **kwargs):
         return self.request("options", url_name, *args, **kwargs)


### PR DESCRIPTION
Dead-code cleanup found while auditing the package. No behavior change on any supported version.

## What went

| Removed | Why it cannot execute |
|---|---|
| `distutils` fallback for `parse_version` (test.py) | `distutils` was **removed from the stdlib in 3.12** (PEP 632), so on 3.12–3.14 this fallback raises `ModuleNotFoundError` rather than importing anything. Also unreachable, since `packaging` was a declared dependency. |
| Django 1.8.2 gate on `trace()` | Floor is Django 4.2. The `else` branch was unreachable. It was also the **only** caller of `parse_version`. |
| `django.core.urlresolvers` fallback (compat.py) | Removed in Django 2.0, eight years ago. |
| `assertURLEqual` `hasattr` fallback (compat.py) | Verified present on both 4.2 and 6.0. |
| `CAPTURE = True` (test.py) | Referenced nowhere in the package, test project, or docs. |

## The payoff: no runtime dependencies

`parse_version` was the only use of `packaging`, which was the package's sole install requirement. `dependencies` is now `[]`, verified against the built wheel rather than the source:

```
Requires-Dist lines: NONE (no runtime deps)
```

For a test utility that lands in every downstream project's dependency tree, that seemed worth the otherwise-cosmetic cleanup.

## What stayed

`assertMessages` keeps its `try/except`. I checked rather than assumed: `MessagesTestMixin` is **absent on 4.2** and present on 6.0, so that shim is load bearing. The DRF `try/except` stays too — it guards a genuinely optional dependency.

## One wrinkle

Replacing compat.py's `try/except` import with a plain `from django.urls import NoReverseMatch, reverse` made `ruff check` delete the line as unused — they are re-exports consumed by `test.py`, and the old `try/except` shape hid that. Re-added with an explicit `# noqa: F401` and a comment saying why. Caught because the test suite then failed to import at all.

## Verification

Ran the suite against the floor, midpoint, and ceiling — not just my local Django:

- Django 4.2 — 100 passed, 2 skipped, 2 xfailed (the extra skip is the Django 5.0+ messages test, expected)
- Django 5.2 — 101 passed, 1 skipped, 2 xfailed
- Django 6.0 — 101 passed, 1 skipped, 2 xfailed

Lint clean. `uv build` produces a valid wheel and sdist.