### PR TITLE
Add a Read the Docs config so the docs can build again

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+# docs/conf.py calls django.setup() and the modules/ pages use autodoc, so the
+# package and its docs extra both have to be installed for the build to import.
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs


### PR DESCRIPTION
The published docs at django-test-plus.readthedocs.io are serving 2018.

## Evidence

RTD's build API reports 68 builds, all from 2018 or earlier. The last successful one:

```
build 7999779  ver=latest  state=finished  success=True
date=2018-10-25  commit=3ae3b28e
```

`3ae3b28` is "Merge pull request #73" — **281 commits** behind `main`, 7 years and 9 months ago. The live `methods.html` is missing not just this month's work but `assertResponseMessages`, `assertResponseTemplateUsed`, and `assertNumQueriesLessThan`.

## Three independent blockers

**1. No config file.** RTD has required one since September 2023. Builds are rejected before checkout. Fixed here.

**2. Missing build dependencies.** `docs/conf.py:24-27` runs `django.setup()` at import time and `docs/modules/test_plus.rst` uses `automodule`, so the package plus its `docs` extra must be installed or `conf.py` raises immediately. In 2018 RTD's default image happened to carry enough; it does not now. Fixed here via `extra_requirements: [docs]`.

**3. RTD tracks a branch that does not exist.** The `latest` version's identifier is `master`; `git ls-remote --heads origin` returns only `main`. The Oct 2018 build was the last commit RTD ever saw under the old name. **This one is not fixable from the repo** — it needs the default branch repointed in the RTD dashboard, which @jefftriplett is doing.

## Verified against a simulated RTD build

Not just "it works on my machine" — a clean Python 3.13 venv, `pip install .[docs]`, then the same `sphinx -T -b html -W` invocation RTD runs:

```
sphinx 9.1.0 | django 6.0.7
build succeeded.   (exit 0)
```

All ten pages generate, including the `modules/` autodoc pages, and the output contains current content — `assertLoginRequired(url_name, *args, method='get', **kwargs)`, the pytest side-by-side, `response_409`, `assertResponseMessages`, `assertURLEqual`.

## On `fail_on_warning: true`

The docs build clean under `-W` today (the three long-standing warnings were cleared in #243), and silent drift is exactly the failure mode this project keeps hitting. The tradeoff: a future Sphinx introducing a warning we do not control would block publishing. If that happens, flip it to `false` — a warning is not worth another stale decade.

## Deliberately not in scope

`pyproject.toml` declares `furo`, `sphinx-copybutton`, and `sphinx-prompt` in the `docs` extra, but `conf.py` uses none of them — `extensions` is only `autodoc` and `viewcode`, and `html_theme = "alabaster"`. Someone started a theme migration that never landed, so the site will come back looking like 2018 even once it builds. That is a visible cosmetic decision and belongs in its own PR. Same for `templates_path = ["_templates"]`, which points at a directory that does not exist.