### PR TITLE
Document where llms.txt and llms-full.txt live

### DIFF
--- a/docs/gen_llms.py
+++ b/docs/gen_llms.py
@@ -59,7 +59,9 @@ class Extractor(HTMLParser):
         self._heading: int | None = None
         self._buf: list[str] = []
         self._code: list[str] = []
-        self.code: list[str] = []
+        self._lang = ""
+        self._href: list[str] = []
+        self.code: list[tuple[str, str]] = []
 
     def handle_starttag(self, tag, attrs):
         a = dict(attrs)
@@ -78,6 +80,17 @@ class Extractor(HTMLParser):
         if tag == "pre":
             self._pre += 1
             self._code = []
+        elif tag == "div" and "language-" in (a.get("class") or ""):
+            # Zensical wraps highlighted blocks in
+            # <div class="language-python highlight">; the language is only there.
+            m = re.search(r"language-(\w+)", a["class"])
+            self._lang = m.group(1) if m else ""
+            self.parts.append("\n")
+        elif tag == "a" and not self._pre:
+            href = a.get("href") or ""
+            self._href.append(href)
+            if href:
+                self.parts.append("[")
         elif tag in self.HEADING:
             self._heading = self.HEADING[tag]
             self._buf = []
@@ -93,6 +106,11 @@ class Extractor(HTMLParser):
         if tag == "a" and self._skip:
             self._skip = max(0, self._skip - 1)
             return
+        if tag == "a" and self.depth and not self._pre and self._href:
+            href = self._href.pop()
+            if href:
+                self.parts.append(f"]({href})")
+            return
         if tag == "article":
             self.depth = max(0, self.depth - 1)
             return
@@ -102,7 +120,7 @@ class Extractor(HTMLParser):
             self._pre = max(0, self._pre - 1)
             # Stash verbatim; whitespace normalisation below must not touch it,
             # or Python indentation in every example is destroyed.
-            self.code.append("".join(self._code).strip("\n"))
+            self.code.append((self._lang, "".join(self._code).strip("\n")))
             self.parts.append(f"\n\n\x00{len(self.code) - 1}\x00\n\n")
             self._code = []
         elif tag in self.HEADING and self._heading:
@@ -124,6 +142,10 @@ class Extractor(HTMLParser):
         else:
             self.parts.append(re.sub(r"[ \t]*\n[ \t]*", " ", data))
 
+    @staticmethod
+    def _fence(lang: str, code: str) -> str:
+        return f"```{lang}\n{code}\n```"
+
     def markdown(self) -> str:
         text = "".join(self.parts)
         text = re.sub(r"[ \t]{2,}", " ", text)
@@ -132,7 +154,7 @@ class Extractor(HTMLParser):
         text = "\n".join(line.rstrip() for line in text.split("\n"))
         text = re.sub(r"\n{3,}", "\n\n", text)
         # Restore code blocks after normalisation, fenced.
-        text = re.sub(r"\x00(\d+)\x00", lambda m: f"```python\n{self.code[int(m.group(1))]}\n```", text)
+        text = re.sub(r"\x00(\d+)\x00", lambda m: self._fence(*self.code[int(m.group(1))]), text)
         return text.strip() + "\n"
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,3 +22,30 @@ class MyViewTests(TestCase):
 - [Testing class-based views](cbvtestcase.md)
 - [Disable logging](disable_logging.md)
 - [API reference](reference.md)
+
+## llms.txt
+
+This documentation is available in the [llms.txt](https://llmstxt.org/) format, a
+Markdown convention suited to LLMs and AI coding assistants.
+
+Two files are published:
+
+- [`llms.txt`](https://django-test-plus.readthedocs.io/en/latest/llms.txt) — a
+  short description of the project plus links to each section of the
+  documentation. The structure is described [here](https://llmstxt.org/#format).
+- [`llms-full.txt`](https://django-test-plus.readthedocs.io/en/latest/llms-full.txt) —
+  the same index with the content of every page included inline, including the
+  generated API reference.
+
+Every page is also published as Markdown alongside its HTML, so you can link an
+assistant at a single section rather than the whole corpus. Append `.md` to the
+page name:
+
+```
+https://django-test-plus.readthedocs.io/en/latest/usage.md
+https://django-test-plus.readthedocs.io/en/latest/methods.md
+https://django-test-plus.readthedocs.io/en/latest/reference.md
+```
+
+These files are not picked up automatically by IDEs or coding agents today, but
+most will use them if you supply a link or paste the text.


### PR DESCRIPTION
We publish `llms.txt`, `llms-full.txt` and a `.md` twin for every page, but nothing in the docs mentioned them, so they were effectively undiscoverable.

Adds an `## llms.txt` section to the index page, modelled on [Pydantic AI's](https://pydantic.dev/docs/ai/overview/#llmstxt): what the format is, both files with links, and a note that agents will use them if given a link even though nothing picks them up automatically yet.

It also documents the thing Pydantic AI does not have — the per-page Markdown twins — so a reader can point an assistant at one section instead of the whole corpus.

## Two generator bugs this surfaced

Writing the section meant reading the generated output closely, which exposed two problems that mattered most for the corpus the section advertises.

**Links were flattened to their text.** "The structure is described [here](https://llmstxt.org/#format)" came out as "described here" — every URL in `llms-full.txt` was being dropped, including the `pytest usage` cross-references between pages. Anchors now round-trip as Markdown links: **25 links in the corpus, previously 0**.

**Every fence was labelled `python`**, including blocks that are just a list of URLs. The language turns out to live on Zensical's wrapping `<div class="language-python highlight">`, not on `<pre>` or `<code>`, so the parser reads it from there. Blocks now emit `python` or `text` correctly — 57 and 3 respectively.

## Verification

- `llms-full.txt`: 34 KB, 25 links, 0 leaked `:::` directives
- 8 `.md` twins, code indentation intact
- Lint clean; 105 passed, 1 skipped, 2 xfailed