### PR TITLE
Order the docs nav explicitly and stop publishing the generator

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,7 +17,7 @@ build:
         - zensical build
         # Zensical has no plugin API yet, so llms.txt, llms-full.txt and the
         # per-page .md twins are generated from the rendered output here.
-        - python docs/gen_llms.py site
+        - python scripts/gen_llms.py site
     post_build:
       - mkdir -p $READTHEDOCS_OUTPUT/html/
       - cp --recursive site/* $READTHEDOCS_OUTPUT/html/

--- a/noxfile.py
+++ b/noxfile.py
@@ -48,7 +48,7 @@ def lint(session: nox.Session) -> None:
 def docs(session: nox.Session) -> None:
     session.install("zensical", "mkdocstrings-python")
     session.run("zensical", "build", *session.posargs)
-    session.run("python", "docs/gen_llms.py", "site")
+    session.run("python", "scripts/gen_llms.py", "site")
 
 
 @nox.session(venv_backend="uv")

--- a/scripts/gen_llms.py
+++ b/scripts/gen_llms.py
@@ -12,18 +12,21 @@ reference page is a mkdocstrings directive in source form:
 Concatenating sources would put that literal text in llms-full.txt and teach a
 reader nothing about the API. Rendering first is the only way to capture it.
 
-Usage: python docs/gen_llms.py [site_dir]
+Usage: python scripts/gen_llms.py [site_dir]
 """
 
 from __future__ import annotations
 
+import os
 import pathlib
 import re
 import sys
 from html.parser import HTMLParser
 from typing import ClassVar
 
-SITE_URL = "https://django-test-plus.readthedocs.io/en/latest"
+# Read the Docs sets this per version, so /en/stable/ does not advertise
+# /en/latest/ URLs. Falls back to latest for local builds.
+SITE_URL = os.environ.get("READTHEDOCS_CANONICAL_URL", "https://django-test-plus.readthedocs.io/en/latest/").rstrip("/")
 NAME = "django-test-plus"
 SUMMARY = "Useful additions to Django's default TestCase."
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -9,6 +9,19 @@ site_description = "Useful additions to Django's default TestCase."
 repo_url = "https://github.com/revsys/django-test-plus"
 edit_uri = "edit/main/docs/"
 
+# Without this, Zensical orders pages alphabetically, which buried Usage at the
+# end and led with the auth helpers. Same order as ORDER in scripts/gen_llms.py.
+nav = [
+  { "Home" = "index.md" },
+  { "Usage" = "usage.md" },
+  { "Methods" = "methods.md" },
+  { "Authentication helpers" = "auth_helpers.md" },
+  { "Ensuring low query counts" = "low_query_counts.md" },
+  { "Testing class-based views" = "cbvtestcase.md" },
+  { "Disable logging" = "disable_logging.md" },
+  { "API reference" = "reference.md" },
+]
+
 # mkdocstrings analyses the source statically with griffe, so unlike Sphinx
 # autodoc it does not import test_plus and needs no django.setup().
 [project.plugins.mkdocstrings.handlers.python]


### PR DESCRIPTION
## Nav order

Zensical falls back to alphabetical ordering when `nav` is unset, so the sidebar read:

```
Authentication Helpers, Testing class-based views, Disable logging,
Ensuring low query counts, Methods, API reference, Usage
```

Usage — the page a new reader wants first — was dead last, and the auth helpers led. Now set explicitly:

```toml
nav = [
  { "Home" = "index.md" },
  { "Usage" = "usage.md" },
  { "Methods" = "methods.md" },
  { "Authentication helpers" = "auth_helpers.md" },
  { "Ensuring low query counts" = "low_query_counts.md" },
  { "Testing class-based views" = "cbvtestcase.md" },
  { "Disable logging" = "disable_logging.md" },
  { "API reference" = "reference.md" },
]
```

API reference stays last, as requested. The order matches `ORDER` in the llms generator, so the site and the corpus now agree instead of drifting.

## Two other improvements

**The generator was being published with the site.** `gen_llms.py` lived in `docs/`, so Zensical treated it as an asset and copied it into the output — it was live at `/en/latest/gen_llms.py`. Moved to `scripts/`, out of `docs_dir`. Confirmed absent from the built site.

**The generator hardcoded `/en/latest/`.** This is a bug I introduced: had `stable` been enabled, the `llms.txt` built for `/en/stable/` would have advertised `latest`'s URLs — pointing readers at docs for a different version than the one they were reading. It now reads `READTHEDOCS_CANONICAL_URL`, which RTD sets per version, falling back to latest for local builds. Verified both ways:

```
READTHEDOCS_CANONICAL_URL=.../en/stable/  ->  .../en/stable/usage.md
unset                                     ->  .../en/latest/usage.md
```

This matters more now that you're re-enabling `stable`.

## Verification

Nav order confirmed from the rendered HTML, not just the config. RTD's build jobs re-run against a fresh clone of the branch: 8 pages, `llms.txt`, `llms-full.txt`, 8 `.md` twins. Lint clean; 105 passed, 1 skipped, 2 xfailed.