### PR TITLE
Turn the landing page into a proper Overview

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,66 @@
-# django-test-plus
+# Overview
 
-> Useful additions to Django's default TestCase.
+> Useful additions to Django's default TestCase, from [REVSYS](https://www.revsys.com/).
 
-Have your tests inherit from `test_plus.test.TestCase` rather than the normal
-`django.test.TestCase`, and the boilerplate mostly goes away.
+Let's face it, writing tests isn't always fun. Part of the reason for that is all
+of the boilerplate you end up writing. django-test-plus is an attempt to cut down
+on some of that when writing Django tests. We guarantee it will increase the time
+before you get carpal tunnel by at least 3 weeks!
+
+If you would like to get started testing your Django apps, or improve how your
+team is testing, we offer [TestStart](https://www.revsys.com/teststart/) to help
+your team dramatically improve your productivity.
+
+## Why use django-test-plus?
+
+It is additive. `test_plus.test.TestCase` subclasses Django's, so everything you
+already know still works and you can adopt the helpers one at a time.
+
+- **Reverse URLs inline.** `self.get('my-url-name')` instead of importing
+  `reverse` and threading it through every call. Args and kwargs pass straight
+  through, and an already-reversed URL works too.
+- **Assert on status codes readably.** `self.assert_http_200_ok()` rather than
+  `self.assertEqual(response.status_code, 200)`, for
+  [most of the status codes](methods.md).
+- **Skip the response variable.** The last response and its context are stored
+  for you, so the assertion helpers default to them.
+- **Create users without ceremony.** [`make_user()`](methods.md) builds one with
+  a sensible username, email and password, takes a permission list, and honours a
+  factory-boy factory if your User model needs one.
+- **Check authentication in a line.** [`assertLoginRequired()`](auth_helpers.md)
+  for any URL and HTTP method, plus a [`login()`](auth_helpers.md) context
+  manager for testing what each user should see.
+- **Keep query counts honest.** [`assertNumQueriesLessThan()`](low_query_counts.md)
+  and [`assertGoodView()`](low_query_counts.md) catch N+1 regressions without
+  pinning an exact number that churns on every change.
+- **Unit test class-based views directly.** [`CBVTestCase`](cbvtestcase.md)
+  invokes a view's methods without the URL resolution, middleware and template
+  stack, when that machinery is not what you are testing.
+- **Works with unittest, pytest and DRF.** The same helpers, three ways — see
+  below.
+
+Maintained by [REVSYS](https://www.revsys.com/), who have been building and
+maintaining Django projects since before 1.0.
+
+## Installation
+
+```shell
+pip install django-test-plus
+```
+
+## Support
+
+- Python 3.10, 3.11, 3.12, 3.13 and 3.14, including the 3.14 free-threaded build (3.14t)
+- Django 4.2 LTS, 5.1, 5.2 LTS, 6.0 and 6.1
+
+## The same test, three ways
+
+The helpers are identical whichever style you write in.
+
+### unittest
+
+Inherit from `test_plus.test.TestCase` rather than the normal
+`django.test.TestCase`:
 
 ```python
 from test_plus.test import TestCase
@@ -13,9 +70,38 @@ class MyViewTests(TestCase):
     def test_the_view(self):
         self.get('my-url-name')
         self.response_200()
+        self.assertResponseContains('<p>Hello, World!</p>')
 ```
 
-- [Usage](usage.md) — including the pytest fixtures and testing DRF views
+### pytest
+
+Ask for the `tp` fixture and every method above is available on it:
+
+```python
+def test_the_view(tp):
+    tp.get('my-url-name')
+    tp.response_200()
+    tp.assertResponseContains('<p>Hello, World!</p>')
+```
+
+### pytest with Django REST Framework
+
+`tp_api` is the same thing backed by DRF's `APIClient`, so you can post JSON and
+assert on the result:
+
+```python
+def test_the_api(tp_api):
+    response = tp_api.post('my-api-view', extra={'format': 'json'})
+    assert response.status_code == 200
+```
+
+Anything that touches the database — `make_user()`, the `login()` context and the
+query counting helpers — needs pytest-django's `db` fixture alongside `tp`. See
+[pytest usage](usage.md#pytest-usage) for the details.
+
+## Where to next
+
+- [Usage](usage.md) — the pytest fixtures and testing DRF views
 - [Methods](methods.md) — requests, status assertions, response and context helpers
 - [Authentication helpers](auth_helpers.md) — `assertLoginRequired` and the `login()` context
 - [Ensuring low query counts](low_query_counts.md) — `assertNumQueriesLessThan` and `assertGoodView`
@@ -41,7 +127,7 @@ Every page is also published as Markdown alongside its HTML, so you can link an
 assistant at a single section rather than the whole corpus. Append `.md` to the
 page name:
 
-```
+```text
 https://django-test-plus.readthedocs.io/en/latest/usage.md
 https://django-test-plus.readthedocs.io/en/latest/methods.md
 https://django-test-plus.readthedocs.io/en/latest/reference.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ already know still works and you can adopt the helpers one at a time.
 - **Skip the response variable.** The last response and its context are stored
   for you, so the assertion helpers default to them.
 - **Create users without ceremony.** [`make_user()`](methods.md) builds one with
-  a sensible username, email and password, takes a permission list, and honours a
+  a sensible username, email, and password, takes a permission list, and honours a
   factory-boy factory if your User model needs one.
 - **Check authentication in a line.** [`assertLoginRequired()`](auth_helpers.md)
   for any URL and HTTP method, plus a [`login()`](auth_helpers.md) context
@@ -34,10 +34,10 @@ already know still works and you can adopt the helpers one at a time.
   and [`assertGoodView()`](low_query_counts.md) catch N+1 regressions without
   pinning an exact number that churns on every change.
 - **Unit test class-based views directly.** [`CBVTestCase`](cbvtestcase.md)
-  invokes a view's methods without the URL resolution, middleware and template
+  invokes a view's methods without the URL resolution, middleware, and template
   stack, when that machinery is not what you are testing.
-- **Works with unittest, pytest and DRF.** The same helpers, three ways — see
-  below.
+- **Works with unittest, pytest, and DRF.** The same helpers, three ways.
+  See below.
 
 Maintained by [REVSYS](https://www.revsys.com/), who have been building and
 maintaining Django projects since before 1.0.
@@ -50,8 +50,8 @@ pip install django-test-plus
 
 ## Support
 
-- Python 3.10, 3.11, 3.12, 3.13 and 3.14, including the 3.14 free-threaded build (3.14t)
-- Django 4.2 LTS, 5.1, 5.2 LTS, 6.0 and 6.1
+- Python 3.10, 3.11, 3.12, 3.13, and 3.14, including the 3.14 free-threaded build (3.14t)
+- Django 4.2 LTS, 5.1, 5.2 LTS, 6.0, and 6.1
 
 ## The same test, three ways
 
@@ -95,16 +95,16 @@ def test_the_api(tp_api):
     assert response.status_code == 200
 ```
 
-Anything that touches the database — `make_user()`, the `login()` context and the
-query counting helpers — needs pytest-django's `db` fixture alongside `tp`. See
-[pytest usage](usage.md#pytest-usage) for the details.
+Anything that touches the database needs pytest-django's `db` fixture alongside
+`tp`. That covers `make_user()`, the `login()` context, and the query counting
+helpers. See [pytest usage](usage.md#pytest-usage) for the details.
 
 ## Where to next
 
-- [Usage](usage.md) — the pytest fixtures and testing DRF views
-- [Methods](methods.md) — requests, status assertions, response and context helpers
-- [Authentication helpers](auth_helpers.md) — `assertLoginRequired` and the `login()` context
-- [Ensuring low query counts](low_query_counts.md) — `assertNumQueriesLessThan` and `assertGoodView`
+- [Usage](usage.md): the pytest fixtures and testing DRF views
+- [Methods](methods.md): requests, status assertions, response, and context helpers
+- [Authentication helpers](auth_helpers.md): `assertLoginRequired` and the `login()` context
+- [Ensuring low query counts](low_query_counts.md): `assertNumQueriesLessThan` and `assertGoodView`
 - [Testing class-based views](cbvtestcase.md)
 - [Disable logging](disable_logging.md)
 - [API reference](reference.md)
@@ -116,10 +116,10 @@ Markdown convention suited to LLMs and AI coding assistants.
 
 Two files are published:
 
-- [`llms.txt`](https://django-test-plus.readthedocs.io/en/latest/llms.txt) — a
+- [`llms.txt`](https://django-test-plus.readthedocs.io/en/latest/llms.txt): a
   short description of the project plus links to each section of the
   documentation. The structure is described [here](https://llmstxt.org/#format).
-- [`llms-full.txt`](https://django-test-plus.readthedocs.io/en/latest/llms-full.txt) —
+- [`llms-full.txt`](https://django-test-plus.readthedocs.io/en/latest/llms-full.txt):
   the same index with the content of every page included inline, including the
   generated API reference.
 

--- a/docs/low_query_counts.md
+++ b/docs/low_query_counts.md
@@ -27,7 +27,7 @@ def test_better_than_nothing(self):
     response = self.assertGoodView('my-url-name')
 ```
 
-Both helpers are available on the pytest `tp` fixture too (see [pytest usage](usage.md#pytest-usage)). Both count queries, so they need database access — ask for pytest-django's `db` fixture alongside `tp`:
+Both helpers are available on the pytest `tp` fixture too (see [pytest usage](usage.md#pytest-usage)). Both count queries, so they need database access. Ask for pytest-django's `db` fixture alongside `tp`:
 
 ```python
 def test_better_than_nothing(tp, db):

--- a/docs/methods.md
+++ b/docs/methods.md
@@ -1,6 +1,6 @@
 # Methods
 
-These examples are written in the unittest style, on a `TestCase` subclass. Every method here is also available on the pytest `tp` fixture — write `tp.get('my-url-name')` where these read `self.get('my-url-name')`. See [pytest usage](usage.md#pytest-usage) for the details.
+These examples are written in the unittest style, on a `TestCase` subclass. Every method here is also available on the pytest `tp` fixture. Write `tp.get('my-url-name')` where these read `self.get('my-url-name')`. See [pytest usage](usage.md#pytest-usage) for the details.
 
 ## reverse(url_name, \*args, \*\*kwargs)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -46,7 +46,7 @@ def test_url_reverse(tp):
     assert expected_url == reversed_url
 ```
 
-Everything documented in `methods`, `auth_helpers`, `low_query_counts` and `cbvtestcase` is available on `tp`. Anywhere those pages write `self.<method>()`, a pytest test writes `tp.<method>()`. The same test written both ways:
+Everything documented in `methods`, `auth_helpers`, `low_query_counts`, and `cbvtestcase` is available on `tp`. Anywhere those pages write `self.<method>()`, a pytest test writes `tp.<method>()`. The same test written both ways:
 
 ```python
 # unittest style

--- a/scripts/gen_llms.py
+++ b/scripts/gen_llms.py
@@ -1,4 +1,4 @@
-"""Generate per-page Markdown, llms.txt and llms-full.txt from a built site.
+"""Generate per-page Markdown, llms.txt, and llms-full.txt from a built site.
 
 Zensical has no plugin API yet (https://zensical.org/docs/community/faqs/) and
 no llms.txt support, so this runs as a post-build step instead. See

--- a/zensical.toml
+++ b/zensical.toml
@@ -12,7 +12,7 @@ edit_uri = "edit/main/docs/"
 # Without this, Zensical orders pages alphabetically, which buried Usage at the
 # end and led with the auth helpers. Same order as ORDER in scripts/gen_llms.py.
 nav = [
-  { "Home" = "index.md" },
+  { "Overview" = "index.md" },
   { "Usage" = "usage.md" },
   { "Methods" = "methods.md" },
   { "Authentication helpers" = "auth_helpers.md" },

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,4 +1,4 @@
-# Zensical configuration — https://zensical.org/docs/
+# Zensical configuration: https://zensical.org/docs/
 #
 # Evaluation of a possible migration away from Sphinx. See issue #248.
 


### PR DESCRIPTION
Reopens #252, which GitHub auto-closed when its base branch was deleted on merging #251. Same commits, retargeted at `main`.

## What changed

The index page was a one-example stub that assumed you already knew what the package was for. It is now an Overview that stands on its own:

- **Framing pulled from the README**: the rationale, the TestStart plug, installation, and the support matrix. Someone landing from a search no longer has to go to GitHub to find out what this is.
- **A new "Why use django-test-plus?" section**, drawn from what the docs actually cover rather than invented: inline URL reversing, readable status assertions, the stored last response, `make_user()`, `assertLoginRequired()` and the `login()` context, the query count helpers, and `CBVTestCase`. Each point links to the page documenting it, and it leads with the thing that lowers the barrier most, which is that it subclasses Django's `TestCase` so the helpers can be adopted one at a time.
- **The same test, three ways**: unittest, pytest via `tp`, and pytest with DRF via `tp_api`, so all three are visible immediately instead of being discovered later in Usage.
- **Sidebar entry renamed** Home to Overview to match the page title.

## House style

Second commit applies the Oxford comma and removes every em dash from the docs. Each em dash was rewritten in context rather than swapped for a generic comma: some became colons in the link lists, some became sentence breaks, and the pytest database note was reflowed so the aside stands as its own sentence. Zero em dashes remain in `docs/`, `scripts/`, `zensical.toml`, or the generated corpus.

## The examples are real

I ran all three styles against the test project before writing them up: a `TestCase` subclass, a `tp` test, and a `tp_api` test posting with `extra={'format': 'json'}`. 3 passed. The page uses placeholder URL names, but the shapes are verified rather than assumed. The DRF one is worth a second look, since `tp_api.post(..., extra={'format': 'json'})` is easy to get subtly wrong.

## Verification

Sidebar order confirmed from rendered HTML: Overview, Usage, Methods, Authentication helpers, Ensuring low query counts, Testing class-based views, Disable logging, API reference.

`llms-full.txt` is ~4,255 words with the new content included and zero em dashes. Lint clean; 105 passed, 1 skipped, 2 xfailed.