### PR TITLE
Clarify that the response_### methods are fully supported

### DIFF
--- a/docs/methods.md
+++ b/docs/methods.md
@@ -148,7 +148,7 @@ def test_better_status(self):
     self.assert_http_200_ok(response)
 ```
 
-Django-test-plus provides a majority of the status codes assertions for you. The status assertions can be found in their own [mixin](https://github.com/revsys/django-test-plus/blob/main/test_plus/status_codes.py) and should be searchable if you're using an IDE like pycharm. It should be noted that in previous versions, django-test-plus had assertion methods in the pattern of `response_###()`, which are still available but have since been deprecated. See below for a list of those methods.
+Django-test-plus provides a majority of the status codes assertions for you. The status assertions can be found in their own [mixin](https://github.com/revsys/django-test-plus/blob/main/test_plus/status_codes.py) and should be searchable if you're using an IDE like pycharm. Earlier versions of django-test-plus used assertion methods in the pattern of `response_###()`. Those are still supported and are not going away, so there is no need to migrate existing tests. See below for a list of them.
 
 Each of the assertion methods takes an optional Django test client `response` and a string `msg` argument that, if specified, is used as the error message when a failure occurs. The methods, `assert_http_301_moved_permanently` and `assert_http_302_found` also take an optional `url` argument that if passed, will check to make sure the `response.url` matches.
 
@@ -162,7 +162,7 @@ def test_status(self):
 
 Which is a bit shorter.
 
-The `response_###()` methods that are deprecated, but still available for use, include:
+The `response_###()` methods, which remain fully supported, include:
 
 - `response_200()`
 - `response_201()`

--- a/test_plus/status_codes.py
+++ b/test_plus/status_codes.py
@@ -1,10 +1,10 @@
 class StatusCodeAssertionMixin:
     """
     The following `assert_http_###_status_name` methods were intentionally added statically instead of dynamically so
-    that code completion in IDEs like PyCharm would work. It is preferred to use these methods over the response_XXX
-    methods, which could be deprecated at some point. The assert methods contain both the number and the status name
-    slug so that people that remember them best by their numeric code and people that remember best by their name will
-    be able to easily find the assertion they need. This was also directly patterned off of what the `Django Rest
+    that code completion in IDEs like PyCharm would work. They are the preferred spelling, but the response_XXX
+    methods are supported permanently and are not deprecated. The assert methods contain both the number and the
+    status name slug so that people that remember them best by their numeric code and people that remember best by
+    their name will be able to easily find the assertion they need. This was also directly patterned off of what the `Django Rest
     Framework uses <https://github.com/encode/django-rest-framework/blob/main/rest_framework/status.py>`_.
     """
 


### PR DESCRIPTION
The `response_###()` methods are staying permanently. The docs currently say otherwise.

## What this changes

Wording only, in three places:

- `docs/methods.md` line 151: "which are still available but have since been deprecated" becomes a statement that they are still supported and there is no need to migrate existing tests.
- `docs/methods.md` line 165: "The `response_###()` methods that are deprecated, but still available for use" becomes "The `response_###()` methods, which remain fully supported".
- `test_plus/status_codes.py`: the mixin docstring hedged with "It is preferred to use these methods over the response_XXX methods, which could be deprecated at some point". It now says the assert spelling is preferred but the `response_XXX` methods are supported permanently and are not deprecated.

`assert_http_###_<status_name>()` is still described as the preferred spelling, since it is more readable and IDE searchable. The point is only that preferring one is not the same as deprecating the other.

## No code change

Worth stating plainly: **nothing in `test_plus` has ever emitted a `DeprecationWarning` for these methods.** The warnings proposed in #221 were never merged. This PR does not remove any runtime behaviour, it only settles documentation that contradicted the intended policy.

## Related: #221

This is the reason I would decline the deprecation half of #221. Adding `DeprecationWarning` to all 12 methods would break downstream CI for anyone running `pytest -W error::DeprecationWarning` or Django's `-Wall`, turning a documented, working method into a hard test failure. For a testing library that is a bad trade for a rename that buys the user nothing, since `response_200()` and `assert_http_200_ok()` do identical work.

The rest of #221 is worth taking on its own: docstrings for every status assertion, and four missing assertions drawn from the MDN status reference (`103 early_hints`, `418 im_a_teapot`, `421 misdirected_request`, `425 too_early`). Those are additive and uncontroversial.

## Verification

Lint clean; 105 passed, 1 skipped, 2 xfailed. Docs build clean and the regenerated corpus carries the new wording.