### PR TITLE
Refresh AUTHORS.txt

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -14,9 +14,25 @@ Guinslym <agmond@gmx.com.br>
 David Arcos - http://davidarcos.net
 Malik Junaid - https://www.facebook.com/malik.junaid27
 Jeff Triplett <jeff.triplett@gmail.com>
-Fábio C. Barrionuevo da Lu
+Fábio C. Barrionuevo da Luz <bnafta@gmail.com>
 Lacey Williams Henschel <laceynwilliams@gmail.com>
 Anton - https://github.com/singleton11
 Natalia Bidart - https://github.com/nessita
 KNiski - https://github.com/KaczuH
 Velda Kiara - https://github.com/VeldaKiara
+Audrey Roy Greenfeld <aroy@alum.mit.edu>
+Danny Wilson <dannywilson32@gmail.com>
+Daniel Hahler <git@thequod.de>
+Nikita Sobolev <mail@sobolevn.me>
+Darius Daftary <dariusdaftary@gmail.com>
+Davit Tovmasyan <davitovmasyan@gmail.com>
+Flavio Curella <flavio.curella@gmail.com>
+Samuel Bishop <lucractius@me.com>
+Tim Gates <tim.gates@iress.com>
+sebatyler - https://github.com/sebatyler
+Andreu Vallbona Plazas <avallbona@gmail.com>
+Nikolaos Michas - https://github.com/nikosmichas
+Kojo Idrissa - https://github.com/kojoidrissa
+Stephen Gilmore <stephen@gilmore.us>
+Chris Rose - https://github.com/offbyone
+Andrés Reverón Molina - https://github.com/andres-holvi


### PR DESCRIPTION
`AUTHORS.txt` had drifted a long way from the commit history.

## What changed

Sixteen people had landed commits without being credited, some of them years ago. Added in order of first contribution:

Audrey Roy Greenfeld, Danny Wilson, Daniel Hahler, Nikita Sobolev, Darius Daftary, Davit Tovmasyan, Flavio Curella, Samuel Bishop, Tim Gates, sebatyler, Andreu Vallbona Plazas, Nikolaos Michas, Kojo Idrissa, Stephen Gilmore, Chris Rose, and Andrés Reverón Molina.

Also fixed **"Fábio C. Barrionuevo da Lu"**, which was missing the last letter of the surname, and filled in the email the entry never had.

## How the list was derived

Walked `git log` for every distinct author, then diffed against the file. Three cases needed care rather than a mechanical match:

- **Already credited under a different spelling**, so not duplicated: Guinsly Mondesir is listed as "Guinslym", Anton Prokhorov as "Anton", Kamil Niski as "KNiski".
- **`goodtune` is Gary Reynolds**, confirmed via the GitHub API, and he is already listed under his name. No second entry.
- **Audrey Roy Greenfeld was masked** by a naive surname match against Daniel Roy Greenfeld. She is a separate contributor and had never been credited.

Bots are excluded (`dependabot`, `dependabot-preview`).

After the change, every non-bot author in the history resolves to an entry: 34 people listed, up from 19.