### PR TITLE
Consolidate pytest and coverage config into pyproject.toml

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,0 @@
-[run]
-omit =
-    test_project/*
-    */.virtualenvs/*
-    */site-packages/*
-    test_plus/compat.py
-    .eggs/*
-    .tox/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,0 @@
-include README.md LICENSE AUTHORS.txt CHANGELOG.md pytest.ini setup.cfg
-recursive-include tests *.py
-prune .eggs
-prune build
-prune dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,10 +75,18 @@ exclude_lines = [
     "if TYPE_CHECKING:",
     'def __str__\(self\)\s?\-?\>?\s?\w*\:',
 ]
-fail_under = 75
+# Consolidating .coveragerc into this file turned fail_under on for the first
+# time: .coveragerc won precedence and had no [report] section, so the old
+# value of 75 was never enforced. Set to today's number so the gate is real,
+# and raise it as coverage improves.
+fail_under = 60
 
 [tool.coverage.run]
-omit = ["docs/*"]
+omit = [
+    "docs/*",
+    "test_project/*",
+    "test_plus/compat.py",
+]
 source = ["test_plus"]
 
 [tool.hatch.build.targets.wheel]
@@ -110,6 +118,6 @@ DJANGO_SETTINGS_MODULE = "test_project.settings"
 # addopts = "--reuse-db --cov"
 addopts = "--reuse-db"
 norecursedirs = ".* build dist docs .eggs/* *.egg-info htmlcov test_plus .git .tox"
-python_files = "tests.py test_*.py *_tests.py"
+python_files = "test*.py *_tests.py"
 pythonpath = ["test_project"]
 testpaths = ["test_project"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,0 @@
-[pytest]
-DJANGO_SETTINGS_MODULE=test_project.settings
-addopts = --reuse-db
-norecursedirs = build dist docs .eggs/* *.egg-info htmlcov test_plus .git .tox
-python_files = test*.py
-pythonpath = test_project/


### PR DESCRIPTION
Audit of the root config files. Three of them duplicated what `pyproject.toml` already declared, and two were silently overriding it.

## pytest.ini: was winning, and the copies had drifted

pytest reported this on every single run:

```
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
```

So `[tool.pytest.ini_options]` was dead config. The two had drifted apart: `testpaths` and a different `python_files` pattern existed only in the ignored copy. Deleted, keeping `pytest.ini`'s broader `python_files` so collection does not change.

Before and after both collect **108 items**, 105 passed / 1 skipped / 2 xfailed. After, pytest reports `configfile: pyproject.toml` with no warning.

## .coveragerc: same problem

`.coveragerc` took precedence over `[tool.coverage]`, so those settings were dead too. Its `omit` list is folded into `pyproject.toml` and the file is deleted.

**This turned `fail_under` on for the first time.** `.coveragerc` had no `[report]` section, so the declared `fail_under = 75` has never actually been enforced, and the project sits at **60%**. Rather than leave `just coverage` failing, the gate is set to 60 with a comment explaining it is today's number and should be raised as coverage improves. Worth knowing the 75 was aspirational, not a standard that regressed.

CI does not run coverage, so nothing in the pipeline changes either way.

## MANIFEST.in: dead

hatchling does not read `MANIFEST.in`. It also referenced `setup.cfg`, which was removed in the move to `pyproject.toml`, and `recursive-include tests *.py` for a `tests/` directory that does not exist. Packaging comes from `[tool.hatch.build.targets.*]`.

Verified the built artifacts are unchanged without it:

```
sdist:  AUTHORS.txt CHANGELOG.md LICENSE README.md pyproject.toml test_plus/*.py
wheel:  test_plus/*.py + dist-info (LICENSE and AUTHORS.txt included)
```

## Kept

`.pre-commit-config.yaml` stays: prek reads it, and it is the lint job.

## Verification

108 collected, 105 passed / 1 skipped / 2 xfailed. Coverage runs and passes its floor. `uv build` produces an identical sdist and wheel. Lint clean. No remaining references to any of the removed files.