### PR TITLE
Drop the stale docs/_build ignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,6 @@ instance/
 .scrapy
 
 # Sphinx documentation
-docs/_build/
 
 # PyBuilder
 .pybuilder/


### PR DESCRIPTION
Tail end of a packaging audit. Smaller than intended, because one of the two nits turned out not to be fixable.

## What changed

`.gitignore` still listed `docs/_build/`, which is Sphinx-era. Sphinx is gone and Zensical builds to `site/`, which is already ignored. One line removed.

## What I tried and backed out

`.gitignore` ships inside the sdist. I attempted to exclude it:

```toml
[tool.hatch.build.targets.sdist]
exclude = [".gitignore"]     # no effect
exclude = ["/.gitignore"]    # no effect either
```

Neither form removes it. Hatchling force-includes the VCS ignore file in sdists regardless of `exclude`, so the config would have been dead weight implying something it does not do. Backed out rather than shipped.

It is harmless: `.gitignore` has been in the sdist since at least 2.4.1 and affects nobody. Noting it here so the next person auditing does not repeat the experiment.

## The audit itself found nothing wrong

For the record, since this PR is the visible tail of it:

- **Wheel** contains only `test_plus/*.py` plus `dist-info`, 14.9 KiB.
- **Sdist** adds only `CHANGELOG.md`, `README.md`, `pyproject.toml`, `PKG-INFO`, and `.gitignore`, 20 KiB.
- **No leaks.** Explicitly checked for `site/`, `docs/`, `test_project/`, `scripts/`, `noxfile.py`, `justfile`, `zensical.toml`, `.readthedocs.yaml`, `.github/`, `.venv`, `.nox`, `uv.lock`, `AGENTS.md`, and `.pre-commit-config.yaml`. Zero hits.
- **No drift.** Diffing the published sdists, `2.4.1 -> 2.5.0 -> 2.6.0` are identical in contents, despite the Sphinx to Zensical migration in between. The published 2.6.0 also matches a fresh local build exactly.

## Verification

Build output identical to the released 2.6.0. Lint clean; 105 passed, 1 skipped, 2 xfailed.