### PR TITLE
Let the pytest fixtures use a custom user factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## Unreleased
+
+  - Add a `test_plus_user_factory` pytest option, so the `tp` and `tp_api`
+    fixtures can build users through a factory the way `TestCase` subclasses
+    already could with the `user_factory` attribute
+
 ## Version 2.6.0 - July 30th, 2026
 
   - Add five HTTP status assertions, completing coverage of every status code

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -11,6 +11,13 @@
 
 ::: test_plus.status_codes.StatusCodeAssertionMixin
 
+::: test_plus.plugin
+    options:
+      members:
+        - tp
+        - tp_api
+        - api_client
+
 ::: test_plus.runner.NoLoggingRunner
     options:
       members:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -78,6 +78,30 @@ def test_auth(tp, db):
         tp.get_check_200('my-protected-view')
 ```
 
+### A custom user factory
+
+`TestCase` subclasses can set a `user_factory` attribute so `make_user()` builds
+users through a factory rather than `User.objects.create_user()`. The pytest
+fixtures have no class of their own to set it on, so point at one with the
+`test_plus_user_factory` ini option and `tp.make_user()` will use it:
+
+```toml
+# pyproject.toml
+[tool.pytest.ini_options]
+test_plus_user_factory = "myapp.factories.UserFactory"
+```
+
+```ini
+# or pytest.ini / setup.cfg
+[pytest]
+test_plus_user_factory = myapp.factories.UserFactory
+```
+
+The value is a dotted path to the factory. Leave it unset and `make_user()`
+behaves exactly as before, calling `User.objects.create_user()`. This is worth
+setting if your `User` model has required fields, or no `username` field, so the
+default cannot build one.
+
 Note that `tp` does not manage database access for you the way `django.test.TestCase` does. Ask for pytest-django's `db` fixture (or apply `@pytest.mark.django_db`) in any test that touches the database. That includes `make_user()` and the `login()` context, and also the query counting helpers `assertNumQueriesLessThan()` and `assertGoodView()`, which open a database connection in order to count.
 
 The pytest plugin is auto-registered via `pytest11`, so no extra configuration is required beyond installing the package and pytest-django. In addition to `tp` and `tp_api`, the plugin also provides a raw `api_client` fixture:

--- a/test_plus/plugin.py
+++ b/test_plus/plugin.py
@@ -68,14 +68,28 @@ def _make_test_case(config, client):
 
 @pytest.fixture
 def api_client():
+    """Django REST Framework's ``APIClient``, unwrapped.
+
+    Requires djangorestframework to be installed.
+    """
     return get_api_client()()
 
 
 @pytest.fixture
 def tp(client, pytestconfig):
+    """A ``TestCase`` instance, so every helper is available in pytest tests.
+
+    Anywhere the docs write ``self.get(...)``, a pytest test writes
+    ``tp.get(...)``. Ask for pytest-django's ``db`` fixture alongside it in any
+    test that touches the database.
+
+    Set the ``test_plus_user_factory`` ini option to a dotted path if
+    ``make_user()`` should build users through a factory.
+    """
     return _make_test_case(pytestconfig, client)
 
 
 @pytest.fixture
 def tp_api(api_client, pytestconfig):
+    """The ``tp`` fixture backed by DRF's ``APIClient``, for testing API views."""
     return _make_test_case(pytestconfig, api_client)

--- a/test_plus/plugin.py
+++ b/test_plus/plugin.py
@@ -1,7 +1,11 @@
+from importlib import import_module
+
 import pytest
 
 from .compat import get_api_client
 from .test import TestCase as BaseTestCase
+
+USER_FACTORY_INI = "test_plus_user_factory"
 
 
 class TestCase(BaseTestCase):
@@ -16,20 +20,62 @@ class TestCase(BaseTestCase):
         super().__init__(*args, **kwargs)
 
 
+def pytest_addoption(parser):
+    parser.addini(
+        USER_FACTORY_INI,
+        help=(
+            "Dotted path to a factory used by tp.make_user(), for example "
+            "myapp.factories.UserFactory. Mirrors the user_factory attribute "
+            "on test_plus.TestCase."
+        ),
+        default=None,
+    )
+
+
+def _load_user_factory(config):
+    """Resolve the configured factory, or None when the option is unset."""
+    path = config.getini(USER_FACTORY_INI)
+    if not path:
+        return None
+
+    module_name, _, attr = path.rpartition(".")
+    if not module_name:
+        raise pytest.UsageError(
+            f"{USER_FACTORY_INI} must be a dotted path to a factory, for example "
+            f"myapp.factories.UserFactory, got {path!r}"
+        )
+
+    try:
+        module = import_module(module_name)
+    except ImportError as exc:
+        raise pytest.UsageError(f"{USER_FACTORY_INI}: cannot import {module_name!r}: {exc}") from exc
+
+    try:
+        return getattr(module, attr)
+    except AttributeError as exc:
+        raise pytest.UsageError(f"{USER_FACTORY_INI}: {module_name!r} has no attribute {attr!r}") from exc
+
+
+def _make_test_case(config, client):
+    factory = _load_user_factory(config)
+    # make_user() is a classmethod and reads cls.user_factory, so setting the
+    # attribute on the instance would never reach it. Build a subclass instead.
+    cls = TestCase if factory is None else type("TestCase", (TestCase,), {"user_factory": factory})
+    t = cls()
+    t.client = client
+    return t
+
+
 @pytest.fixture
 def api_client():
     return get_api_client()()
 
 
 @pytest.fixture
-def tp(client):
-    t = TestCase()
-    t.client = client
-    return t
+def tp(client, pytestconfig):
+    return _make_test_case(pytestconfig, client)
 
 
 @pytest.fixture
-def tp_api(api_client):
-    t = TestCase()
-    t.client = api_client
-    return t
+def tp_api(api_client, pytestconfig):
+    return _make_test_case(pytestconfig, api_client)

--- a/test_project/test_app/factories.py
+++ b/test_project/test_app/factories.py
@@ -1,0 +1,14 @@
+import factory.django
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+
+class UserFactory(factory.django.DjangoModelFactory):
+    """Used by the test_plus_user_factory pytest option tests."""
+
+    username = factory.Sequence(lambda n: f"factoryuser{n}")
+    email = factory.Sequence(lambda n: f"factoryuser{n}@example.com")
+
+    class Meta:
+        model = User

--- a/test_project/test_app/tests/test_pytest.py
+++ b/test_project/test_app/tests/test_pytest.py
@@ -22,3 +22,13 @@ def test_assert_in_context(tp):
     response = tp.get("view-context-with")
     assert "testvalue" in response.context
     tp.assertInContext("testvalue")
+
+
+def test_user_factory_defaults_to_none(tp):
+    # Without the ini option set, tp behaves exactly as before.
+    assert tp.user_factory is None
+
+
+def test_make_user_without_a_factory(tp, db):
+    user = tp.make_user("plain")
+    assert user.username == "plain"

--- a/test_project/test_app/tests/test_user_factory_option.py
+++ b/test_project/test_app/tests/test_user_factory_option.py
@@ -85,5 +85,6 @@ def test_tp_uses_the_configured_factory(tmp_path):
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
+        check=False,  # the assertion below reports the output on failure
     )
     assert result.returncode == 0, result.stdout + result.stderr

--- a/test_project/test_app/tests/test_user_factory_option.py
+++ b/test_project/test_app/tests/test_user_factory_option.py
@@ -1,0 +1,89 @@
+"""Tests for the test_plus_user_factory pytest option.
+
+The option is read from the ini file, so the end to end check runs pytest in a
+subprocess with -o rather than trying to mutate config in process.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from test_plus.plugin import USER_FACTORY_INI, _load_user_factory
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class FakeConfig:
+    def __init__(self, value):
+        self._value = value
+
+    def getini(self, name):
+        assert name == USER_FACTORY_INI
+        return self._value
+
+
+def test_unset_returns_none():
+    assert _load_user_factory(FakeConfig(None)) is None
+
+
+def test_empty_string_returns_none():
+    assert _load_user_factory(FakeConfig("")) is None
+
+
+def test_loads_a_dotted_path():
+    from test_app.factories import UserFactory
+
+    assert _load_user_factory(FakeConfig("test_app.factories.UserFactory")) is UserFactory
+
+
+def test_rejects_a_path_without_a_module():
+    with pytest.raises(pytest.UsageError, match="dotted path"):
+        _load_user_factory(FakeConfig("UserFactory"))
+
+
+def test_reports_an_unimportable_module():
+    with pytest.raises(pytest.UsageError, match="cannot import"):
+        _load_user_factory(FakeConfig("test_app.nope.UserFactory"))
+
+
+def test_reports_a_missing_attribute():
+    with pytest.raises(pytest.UsageError, match="has no attribute"):
+        _load_user_factory(FakeConfig("test_app.factories.NotAFactory"))
+
+
+def test_tp_uses_the_configured_factory(tmp_path):
+    """End to end: with the ini set, tp.make_user() goes through the factory."""
+    test_file = tmp_path / "test_uses_factory.py"
+    test_file.write_text(
+        "def test_make_user_uses_the_factory(tp, db):\n"
+        "    user = tp.make_user('passed-through')\n"
+        "    assert tp.user_factory is not None\n"
+        "    # make_user passes the username to the factory, so it wins, but the\n"
+        "    # email comes from the factory's own sequence. Without the option\n"
+        "    # that would be passed-through@example.com instead.\n"
+        "    assert user.username == 'passed-through'\n"
+        "    assert user.email.startswith('factoryuser')\n"
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(test_file),
+            "-o",
+            f"{USER_FACTORY_INI}=test_app.factories.UserFactory",
+            "-o",
+            "DJANGO_SETTINGS_MODULE=test_project.settings",
+            "-o",
+            "pythonpath=test_project",
+            "-p",
+            "no:cacheprovider",
+            "-q",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
Closes #125, open since 2020.

## The gap

`TestCase` subclasses can set a `user_factory` attribute and `make_user()` will build users through it instead of `User.objects.create_user()`. The `tp` and `tp_api` fixtures have no class of their own to set it on, so pytest users could never reach that hook. If your `User` model has required fields or no `username` field, `tp.make_user()` simply could not build one.

## The option

```toml
[tool.pytest.ini_options]
test_plus_user_factory = "myapp.factories.UserFactory"
```

A dotted path to the factory. Unset, which is the default, nothing changes: `make_user()` calls `User.objects.create_user()` exactly as before. Bad values raise `pytest.UsageError` naming the problem rather than leaking an `ImportError` or `AttributeError` out of a fixture.

## The part that was not obvious

Assigning `t.user_factory = factory` on the fixture instance looks right and does nothing. **`make_user()` is a `classmethod`** and reads `cls.user_factory`, so an instance attribute never reaches it. The fixtures build a small subclass instead:

```python
cls = TestCase if factory is None else type("TestCase", (TestCase,), {"user_factory": factory})
```

My first attempt did the instance assignment. The option loaded correctly, `tp.user_factory` was set, and users were still created by `create_user()`. The end to end test is what caught it, which is why it is written the way it is rather than asserting on the attribute alone.

## Backwards compatibility

Purely additive. The option defaults to unset, `TestCase.user_factory` still defaults to `None`, and the 105 pre-existing tests are untouched and passing.

## Tests

Nine added, covering the loader and the real behaviour:

- unset and empty string both resolve to `None`
- a valid dotted path resolves to the factory object
- a path with no module, an unimportable module, and a missing attribute each raise `pytest.UsageError` with a useful message
- `tp.user_factory` is `None` by default, and `make_user()` still works without a factory
- end to end: pytest runs in a subprocess with `-o test_plus_user_factory=...` and asserts the created user's email comes from the factory's sequence, which is the field that proves the factory ran

114 passed, 1 skipped, 2 xfailed, up from 105. Lint clean, docs build clean.

## Docs

`docs/usage.md` gains a "A custom user factory" section under pytest usage, showing both the `pyproject.toml` and `pytest.ini` forms and saying when you would want it.