### PR TITLE
Add Documentation URL to project.urls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ content-type = "text/markdown"
 
 [project.urls]
 Changelog = "https://github.com/revsys/django-test-plus/blob/main/CHANGELOG.md"
+Documentation = "https://django-test-plus.readthedocs.io"
 Homepage = "https://github.com/revsys/django-test-plus/"
 
 [project.entry-points]


### PR DESCRIPTION
Adds a `Documentation` entry to `[project.urls]` pointing at https://django-test-plus.readthedocs.io, so the docs link appears on the PyPI project page (and in `pip show`).

Verified the `Project-URL: Documentation, ...` line is present in the built wheel metadata. Lint clean.