### PR TITLE
Test against Python 3.15

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -25,6 +25,8 @@ jobs:
           - "3.13"
           - "3.14"
           - "3.14t"
+          - "3.15"
+          - "3.15t"
         django-version:
           - "4.2"  # LTS
           - "5.1"
@@ -59,6 +61,15 @@ jobs:
             django-version: "5.1"
           - python-version: "3.14t"
             django-version: "5.1"
+          # Django 4.2 and 5.1 are not compatible with Python 3.15 either
+          - python-version: "3.15"
+            django-version: "4.2"
+          - python-version: "3.15t"
+            django-version: "4.2"
+          - python-version: "3.15"
+            django-version: "5.1"
+          - python-version: "3.15t"
+            django-version: "5.1"
 
     steps:
       - uses: actions/checkout@v4
@@ -67,8 +78,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          # 3.15 has no final release yet. Harmless for the others, and can be
+          # dropped once 3.15 ships.
+          allow-prereleases: true
           cache: "pip"
-          cache-dependency-path: '**/setup.cfg'
+          cache-dependency-path: '**/pyproject.toml'
 
       - name: Install dependencies
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## Unreleased
+
+  - Test against Python 3.15, including the free-threaded build (3.15t). It is
+    still in beta, so the trove classifier is published but support is not
+    promised until the final release.
+
 ## Version 2.6.1 - July 31st, 2026
 
   - Add PyPI, Python, and Django version badges to the README and docs

--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ to help your team dramatically improve your productivity.
 
 ## Support
 
-- Python 3.10, 3.11, 3.12, 3.13, and 3.14, including the 3.14 free-threaded
-  build (3.14t).
+- Python 3.10, 3.11, 3.12, 3.13, 3.14, and 3.15, including the free-threaded
+  builds (3.14t and 3.15t). Python 3.15 is still in beta, so it is tested but
+  not yet promised.
 
 - Django 4.2 LTS, 5.1, 5.2 LTS, 6.0, and 6.1.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,8 @@ pip install django-test-plus
 
 ## Support
 
-- Python 3.10, 3.11, 3.12, 3.13, and 3.14, including the 3.14 free-threaded build (3.14t)
+- Python 3.10, 3.11, 3.12, 3.13, 3.14, and 3.15, including the free-threaded builds
+  (3.14t and 3.15t). Python 3.15 is still in beta, so it is tested but not yet promised.
 - Django 4.2 LTS, 5.1, 5.2 LTS, 6.0, and 6.1
 
 ## The same test, three ways

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,7 +2,7 @@ import nox
 
 DJANGO_VERSIONS = ["4.2", "5.1", "5.2", "6.0", "6.1"]
 DRF_VERSIONS = ["3.15", "3.16"]
-PYTHON_VERSIONS = ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
+PYTHON_VERSIONS = ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
 
 # Django versions that have no final release yet need a specifier that opts in
 # to pre-releases. Naming the pre-release also lets the same spec pick up the
@@ -20,6 +20,11 @@ INVALID_PYTHON_DJANGO_SESSIONS = [
     ("3.14", "5.1"),
     ("3.14t", "4.2"),
     ("3.14t", "5.1"),
+    # Django 4.2 and 5.1 are not compatible with Python 3.15 either
+    ("3.15", "4.2"),
+    ("3.15", "5.1"),
+    ("3.15t", "4.2"),
+    ("3.15t", "5.1"),
 ]
 INVALID_DRF_DJANGO_SESSIONS = []
 INVALID_DRF_PYTHON_SESSIONS = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: Free Threading :: 3 - Stable",
 ]
 dependencies = []


### PR DESCRIPTION
Python 3.15 is at **beta 3**; the final release is due in October. This adds it to the matrix and publishes the classifier without promising support yet.

## Verified before wiring anything up

Ran the suite on 3.15.0b3 against each Django version rather than assuming:

| Django | 3.15 |
|---|---|
| 4.2 | 25 failed |
| 5.1 | 25 failed |
| 5.2 | 105 passed |
| 6.0 | 105 passed |
| 6.1 | 105 passed |

Same compatibility line as 3.14, so 4.2 and 5.1 get the same exclusions in both the workflow and the noxfile. The free-threaded build was checked too: **3.15t + Django 6.1 passes**, 96 passed / 10 skipped / 2 xfailed, with the skips being the DRF tests that do not install there.

Confirmed the excluded combinations skip rather than run:

```
nox > Session tests-3.15(django='4.2') skipped.
```

They still appear in `nox -l`, which is how the existing 3.14 exclusions behave too.

## allow-prereleases

`actions/setup-python` will not resolve a beta without it, so it is set on the matrix job. Harmless for the released versions, and the comment says to drop it once 3.15 ships. `lint.yml` pins 3.13 and does not need it.

## Classifier

`Programming Language :: Python :: 3.15` is a valid trove classifier, checked against the `trove-classifiers` package, so this will not break a PyPI upload.

The README and docs say 3.15 is tested but in beta and not yet promised, so the support list is not overclaiming.

## Unrelated fix in the same file

The pip cache used `cache-dependency-path: '**/setup.cfg'`. `setup.cfg` was removed in 2.4.1 during the hatchling migration, so the key has never matched and the cache has been dead ever since. Repointed at `pyproject.toml`.

## Verification

Lint clean; 105 passed, 1 skipped, 2 xfailed on the default interpreter. Workflow YAML parses, matrix is 8 Python versions with 12 exclusions.